### PR TITLE
fix(sticky-reader): dropdown occlusion, mobile drawer pinned open, toolbar restructuring

### DIFF
--- a/xExtension-StickyReader/extension.php
+++ b/xExtension-StickyReader/extension.php
@@ -30,10 +30,15 @@ class StickyReaderExtension extends Minz_Extension {
             $config = [];
             foreach (array_keys(self::DEFAULTS) as $key) {
                 if ($key === 'scroll_target') {
-                    $val = Minz_Request::param($key, 'control_bar');
+                    // paramString() returns '' when absent, which is not in
+                    // SCROLL_TARGETS, so the guard below supplies the default.
+                    $val = Minz_Request::paramString($key);
                     $config[$key] = in_array($val, self::SCROLL_TARGETS, true) ? $val : 'control_bar';
                 } else {
-                    $config[$key] = Minz_Request::param($key) === '1';
+                    // The form posts a hidden '0' before each checkbox's '1',
+                    // and paramBoolean() reads both — same result as the old
+                    // `=== '1'`, without the deprecated untyped accessor.
+                    $config[$key] = Minz_Request::paramBoolean($key);
                 }
             }
             $this->setUserConfiguration($config);

--- a/xExtension-StickyReader/metadata.json
+++ b/xExtension-StickyReader/metadata.json
@@ -2,7 +2,7 @@
     "name": "Sticky Reader",
     "author": "featurecreep-cron",
     "description": "Scroll straight to articles, keep controls within reach, read distraction-free",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "entrypoint": "StickyReader",
     "type": "user"
 }

--- a/xExtension-StickyReader/metadata.json
+++ b/xExtension-StickyReader/metadata.json
@@ -2,7 +2,7 @@
     "name": "Sticky Reader",
     "author": "featurecreep-cron",
     "description": "Scroll straight to articles, keep controls within reach, read distraction-free",
-    "version": "0.2.9",
+    "version": "0.3.0",
     "entrypoint": "StickyReader",
     "type": "user"
 }

--- a/xExtension-StickyReader/metadata.json
+++ b/xExtension-StickyReader/metadata.json
@@ -2,7 +2,7 @@
     "name": "Sticky Reader",
     "author": "featurecreep-cron",
     "description": "Scroll straight to articles, keep controls within reach, read distraction-free",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "entrypoint": "StickyReader",
     "type": "user"
 }

--- a/xExtension-StickyReader/static/script.js
+++ b/xExtension-StickyReader/static/script.js
@@ -9,17 +9,27 @@
   var scrollPadding = 0;
   var scrollContainer = null; // window or #rv-content
 
-  function getScrollContainer() {
-    return scrollContainer || window;
+  // restructureLayout() creates #rv-content at every viewport width, but the CSS
+  // that makes it a scrolling column is gated behind FreshRSS's 841px breakpoint
+  // (see style.css). Below that the div is an inert wrapper and the page scrolls
+  // on the window as usual, so decide by whether it actually scrolls rather than
+  // by whether it exists — otherwise scroll anchoring silently drives an element
+  // with nowhere to go.
+  function activeScrollContainer() {
+    if (scrollContainer && scrollContainer.scrollHeight > scrollContainer.clientHeight) {
+      return scrollContainer;
+    }
+    return null;
   }
 
   function getScrollTop() {
-    if (scrollContainer) return scrollContainer.scrollTop;
-    return window.scrollY;
+    var container = activeScrollContainer();
+    return container ? container.scrollTop : window.scrollY;
   }
 
   function doScrollBy(delta) {
-    if (scrollContainer) scrollContainer.scrollBy({ top: delta, behavior: 'instant' });
+    var container = activeScrollContainer();
+    if (container) container.scrollBy({ top: delta, behavior: 'instant' });
     else window.scrollBy({ top: delta, behavior: 'instant' });
   }
 
@@ -95,7 +105,8 @@
     var currentTop = header.getBoundingClientRect().top;
     // In restructured layout, the content area starts at the top of #rv-content
     // scrollPadding = height of sticky nav within the content
-    var contentTop = scrollContainer ? scrollContainer.getBoundingClientRect().top : 0;
+    var container = activeScrollContainer();
+    var contentTop = container ? container.getBoundingClientRect().top : 0;
     var targetTop = contentTop + scrollPadding;
     var delta = currentTop - targetTop;
     if (Math.abs(delta) > 2) {

--- a/xExtension-StickyReader/static/script.js
+++ b/xExtension-StickyReader/static/script.js
@@ -168,6 +168,11 @@
     var navMenu = document.querySelector('.nav_menu');
     if (!navMenu) return;
 
+    // Tells the stylesheet it may restructure the toolbar into a flex row.
+    // Without a feed name there is nothing to align against, so the nav is left
+    // as FreshRSS renders it — centred, and free to wrap when space runs out.
+    document.documentElement.classList.add('rv-has-feed-name');
+
     feedNameEl = document.createElement('div');
     feedNameEl.className = 'rv-feed-name';
 

--- a/xExtension-StickyReader/static/style.css
+++ b/xExtension-StickyReader/static/style.css
@@ -125,11 +125,29 @@
     contain: none !important;
 }
 
-/* ===== Nav flex layout (all modes) ===== */
-.rv-scroll-active .nav_menu {
+/* ===== Nav flex layout — only when we have inserted a feed name =====
+ *
+ * Gated on .rv-has-feed-name, set by initTitleBar(). This block used to key on
+ * .rv-scroll-active alone, so it applied whenever scroll anchoring was on, even
+ * with the feed name switched off. Two things followed from that:
+ *
+ *   1. FreshRSS centres the toolbar with `text-align: center` on .nav_menu, and
+ *      text-align does not position flex items. Forcing display:flex therefore
+ *      silently replaced centred with left-aligned for anyone who wanted sticky
+ *      scrolling but no feed name.
+ *   2. Stock .group is inline-flex inside a block, so groups wrap onto another
+ *      row when the window is too narrow. flex-wrap: nowrap removed that, and
+ *      because .group is also flex-shrink: 0, nothing could wrap OR shrink —
+ *      controls simply became unreachable instead of overflowing.
+ *
+ * So: no feed name, no restructuring — stock centred layout is left alone.
+ * With a feed name, flex gives us name-left/controls-right via .rv-spacer, and
+ * wrap keeps the stock overflow behaviour.
+ */
+.rv-scroll-active.rv-has-feed-name .nav_menu {
     display: flex !important;
     align-items: center !important;
-    flex-wrap: nowrap !important;
+    flex-wrap: wrap !important;
 }
 
 /* Feed/category name in toolbar */
@@ -151,8 +169,10 @@
     min-width: 0 !important;
 }
 
-/* Prevent control groups from shrinking */
-.rv-scroll-active .nav_menu .group {
+/* Keep control groups at their natural size so they wrap rather than squash.
+   Scoped to the same class as the flex block — without it these are stock
+   inline-flex elements and must not be given flex-item properties. */
+.rv-scroll-active.rv-has-feed-name .nav_menu .group {
     flex-shrink: 0 !important;
 }
 

--- a/xExtension-StickyReader/static/style.css
+++ b/xExtension-StickyReader/static/style.css
@@ -81,6 +81,30 @@
     contain: layout style !important;
 }
 
+/* ...except the one article whose dropdown is open.
+ *
+ * `contain: layout` makes each article a stacking context, and a stacking
+ * context traps z-index. FreshRSS's topline dropdowns (My labels, Sharing)
+ * rely on `z-index: 1000` to paint over the articles below them, so once that
+ * index is resolved inside a single article row instead of against the page,
+ * the part of the menu that overflows a collapsed row is painted underneath
+ * the next article. Measured: the menu renders at full height and hangs ~70px
+ * past the row, and the topmost element inside that overflow is the following
+ * article's <time>. It is occluded, not clipped.
+ *
+ * Releasing containment for the open article only — never more than one at a
+ * time, since :target matches a single fragment — keeps the optimisation for
+ * every other row. Do not "simplify" this by deleting the rule above; layout
+ * containment is what scopes recalc on long lists, which is the point of the
+ * extension. Dropping to `contain: style` would fix the symptom by abandoning
+ * that.
+ *
+ * Reported as #14 (share menu) and #15 (label menu), which are one defect.
+ */
+.rv-scroll-active .flux:has(.dropdown-target:target) {
+    contain: none !important;
+}
+
 /* ===== Nav flex layout (all modes) ===== */
 .rv-scroll-active .nav_menu {
     display: flex !important;

--- a/xExtension-StickyReader/static/style.css
+++ b/xExtension-StickyReader/static/style.css
@@ -13,62 +13,82 @@
     position: static !important;
 }
 
-/* ===== search_bar mode: restructured layout ===== */
-/* Header stays at top, #global becomes flex row, content scrolls independently */
-.rv-scroll-active.rv-sticky-header {
-    height: 100% !important;
-    overflow: hidden !important;
-}
+/* ===== search_bar mode: restructured layout =====
+ *
+ * Desktop only. Below 840px FreshRSS turns .aside into a collapsed navigation
+ * drawer — `position: fixed; left: -1px; width: 0; z-index: 100` — that opens
+ * only when `.visible` is added. The rules below used to apply at every width,
+ * and because they override `width` but never `position`, the drawer became a
+ * permanently-open 301px panel pinned over the page: it covered the left of the
+ * toolbar and the article list, which read as "the toolbar moved right" when in
+ * fact the toolbar had not moved at all.
+ *
+ * Measured on FreshRSS 1.29.x / theme Origine: `.aside` position flips
+ * fixed → static → fixed at viewport widths 737 / 1292 / 580 while its width
+ * stays 284.323px throughout. Both halves of the mechanism.
+ *
+ * 841px is FreshRSS's own breakpoint (max-width: 840px), not one of ours. If
+ * upstream moves theirs, this has to move with it.
+ *
+ * Reported as the first half of #14.
+ */
+@media (min-width: 841px) {
+    /* Header stays at top, #global becomes flex row, content scrolls independently */
+    .rv-scroll-active.rv-sticky-header {
+        height: 100% !important;
+        overflow: hidden !important;
+    }
 
-.rv-scroll-active.rv-sticky-header body {
-    height: 100% !important;
-    overflow: hidden !important;
-    display: flex !important;
-    flex-direction: column !important;
-    margin: 0 !important;
-}
+    .rv-scroll-active.rv-sticky-header body {
+        height: 100% !important;
+        overflow: hidden !important;
+        display: flex !important;
+        flex-direction: column !important;
+        margin: 0 !important;
+    }
 
-.rv-scroll-active.rv-sticky-header .header {
-    flex: 0 0 auto !important;
-    width: 100% !important;
-}
+    .rv-scroll-active.rv-sticky-header .header {
+        flex: 0 0 auto !important;
+        width: 100% !important;
+    }
 
-.rv-scroll-active.rv-sticky-header #global {
-    flex: 1 1 auto !important;
-    display: flex !important;
-    flex-direction: row !important;
-    overflow: hidden !important;
-    min-height: 0 !important;
-}
+    .rv-scroll-active.rv-sticky-header #global {
+        flex: 1 1 auto !important;
+        display: flex !important;
+        flex-direction: row !important;
+        overflow: hidden !important;
+        min-height: 0 !important;
+    }
 
-.rv-scroll-active.rv-sticky-header .aside {
-    display: block !important;
-    width: 301px !important;
-    flex-shrink: 0 !important;
-    overflow-y: auto !important;
-    will-change: scroll-position !important;
-    -webkit-overflow-scrolling: touch !important;
-    contain: strict !important;
-}
+    .rv-scroll-active.rv-sticky-header .aside {
+        display: block !important;
+        width: 301px !important;
+        flex-shrink: 0 !important;
+        overflow-y: auto !important;
+        will-change: scroll-position !important;
+        -webkit-overflow-scrolling: touch !important;
+        contain: strict !important;
+    }
 
-/* Remove inner tree scroll — aside itself is the scroll container now */
-.rv-scroll-active.rv-sticky-header .aside .tree {
-    max-height: none !important;
-    overflow-y: visible !important;
-}
+    /* Remove inner tree scroll — aside itself is the scroll container now */
+    .rv-scroll-active.rv-sticky-header .aside .tree {
+        max-height: none !important;
+        overflow-y: visible !important;
+    }
 
-.rv-scroll-active.rv-sticky-header #rv-content {
-    flex: 1 1 auto !important;
-    overflow-y: auto !important;
-    min-width: 0 !important;
-    will-change: scroll-position !important;
-    -webkit-overflow-scrolling: touch !important;
-}
+    .rv-scroll-active.rv-sticky-header #rv-content {
+        flex: 1 1 auto !important;
+        overflow-y: auto !important;
+        min-width: 0 !important;
+        will-change: scroll-position !important;
+        -webkit-overflow-scrolling: touch !important;
+    }
 
-.rv-scroll-active.rv-sticky-header #rv-content .nav_menu {
-    position: sticky !important;
-    top: 0 !important;
-    z-index: 999 !important;
+    .rv-scroll-active.rv-sticky-header #rv-content .nav_menu {
+        position: sticky !important;
+        top: 0 !important;
+        z-index: 999 !important;
+    }
 }
 
 /* GPU-accelerate sticky nav to avoid repaint on scroll */


### PR DESCRIPTION
Fixes #15
Fixes #14

Three defects in Sticky Reader, all measured on a live instance rather than reasoned about. Bumps the extension to 0.3.1.

## Topline dropdowns painted underneath the next article

Reported twice — as the label menu in #15 and the share menu in #14. One defect: `entry_header.phtml` builds both as sibling `.dropdown` elements in the same article topline, and FreshRSS has no share control in the nav at all.

`contain: layout` made every `.flux` a stacking context, and a stacking context traps `z-index`. The topline dropdowns rely on `z-index: 1000` to paint over the rows below them, so on a collapsed article the overflowing part of the menu was drawn under its neighbour.

Measured with the menu open:

```
VERDICT:                OCCLUDED by another article row
menuOverflowsArticleBy:  70.3px
elementAtProbe:          TIME     <- the next article's date
menuVisibleHeight:       75.7     <- vs scrollHeight 73, so not clipped
articleContain:          layout style
```

Full height, hanging past the row, with the following article painted on top of it. Occluded, not clipped — which ruled out chasing an `overflow` culprit.

The fix releases containment for `:has(.dropdown-target:target)` only. Never more than one article at a time, so the recalc scoping the rule exists for survives.

## search_bar layout pinned the mobile drawer open

Below 840px FreshRSS turns `.aside` into a collapsed drawer — `position: fixed; width: 0` — that opens only when `.visible` is set. The `search_bar` rules overrode `width` and never touched `position`, so the drawer became a permanently open 301px panel floating over the page, covering the left of the toolbar and the article list.

It reads as "the toolbar moved right". The toolbar never moved; it was underneath.

Resize sweep, ~60 samples in both directions:

| viewport | `.aside` position | `.aside` spans | article left |
|---|---|---|---|
| 586–827 | `fixed` | -1–301 | **0** |
| 841–3322 | `static` | 0–302 | 302 |

Clean flip at FreshRSS's own 840px breakpoint, so the whole `rv-sticky-header` block now sits behind `@media (min-width: 841px)`.

`restructureLayout()` still creates `#rv-content` at every width, so scroll anchoring would have kept driving a div that no longer scrolls. The container is now chosen by whether it actually scrolls, not by whether it exists.

## Toolbar restructured even with the feed name off

The nav flex block keyed on `.rv-scroll-active` alone, so it applied whenever scroll anchoring was on. Two consequences:

- FreshRSS centres the toolbar with `text-align: center`, and **`text-align` does not position flex items**. Forcing `display: flex` silently replaced centred with left-aligned.
- Stock `.group` is `inline-flex` inside a block and wraps when space runs out. `flex-wrap: nowrap` removed that, and since `.group` is also `flex-shrink: 0`, nothing could wrap *or* shrink — controls became unreachable rather than overflowing.

Now gated behind `.rv-has-feed-name`, set by `initTitleBar()`. No feed name means no restructuring: stock centred, stock wrapping. With a feed name you get name-left / controls-right via `.rv-spacer`, and `wrap` replaces `nowrap` so overflow still works.

This also answers #14's "top menu should be centered": the right-alignment is now a property of the feed-name option rather than of sticky scrolling, so turning that option off restores the stock layout.

## Deprecation notices on every config save

`extension.php` used `Minz_Request::param()`, marked `#[Deprecated('Use typed versions instead')]` upstream. Six notices per save — one from line 33, five from line 36 — because the loop walks six `DEFAULTS` keys and only `scroll_target` takes the first branch.

Replaced with `paramString()` and `paramBoolean()`. Both are drop-ins: `paramString()` returns `''`, which is not in `SCROLL_TARGETS`, so the existing guard already supplies the default; `paramBoolean()` resolves an absent checkbox to `false` via `paramTernary()`, matching the old `=== '1'`.

## Known limitation

With wrapping enabled and `.rv-spacer` still at `flex: 1 1 0`, a wrapped line containing the spacer will right-align whatever follows it on that line. That may look lopsided at narrow widths. Flagging rather than hiding it — it needs eyes, not reasoning.
