### PR TITLE
fix(sticky-reader): let any article anchor to the top at the end of a list

### DIFF
--- a/xExtension-StickyReader/metadata.json
+++ b/xExtension-StickyReader/metadata.json
@@ -2,7 +2,7 @@
     "name": "Sticky Reader",
     "author": "featurecreep-cron",
     "description": "Scroll straight to articles, keep controls within reach, read distraction-free",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "entrypoint": "StickyReader",
     "type": "user"
 }

--- a/xExtension-StickyReader/static/style.css
+++ b/xExtension-StickyReader/static/style.css
@@ -91,6 +91,35 @@
     }
 }
 
+/* ===== Trailing space, so any article can reach the top =====
+ *
+ * Scroll anchoring puts the opened article's header at the top of the scrolling
+ * area. That only works while enough content remains below it to scroll; near
+ * the end of a list the scroll clamps at its maximum and the article settles
+ * wherever the leftover height allows, with dead space under it. Nothing about
+ * this is specific to `k` — `j`, `p`, `n` and clicking a header all end the same
+ * way once the remaining articles are shorter than the viewport, which is why a
+ * short list shows it immediately and a long one only at the bottom.
+ *
+ * Measured on a live FreshRSS 1.29.x instance, 11-article list, 1700x960,
+ * search_bar mode, target position 77px. Without trailing space five of ten
+ * openings landed at 135, 223, 257, 266 and 342px, each with scrollTop already
+ * equal to scrollHeight - clientHeight. With this rule, all twenty openings —
+ * ten with `j`, ten back with `k` — landed at 76-77px.
+ *
+ * One viewport is always sufficient: the worst case is a zero-height article
+ * last in the list, which needs exactly the viewport height behind it. The
+ * space is only reachable by scrolling past the final article, so it costs
+ * nothing until you are there, and `#stream` is the last child of the scrolling
+ * element in both arrangements — of #rv-content in the restructured search_bar
+ * layout, and of the page itself in every other mode.
+ *
+ * Reported as #18.
+ */
+.rv-scroll-active #stream {
+    padding-bottom: 100vh !important;
+}
+
 /* GPU-accelerate sticky nav to avoid repaint on scroll */
 .rv-scroll-active .nav_menu {
     transform: translateZ(0) !important;


### PR DESCRIPTION
Closes #18.

## What breaks

Scroll anchoring puts the opened article's header at the top of the scrolling area. That only works while enough content remains below it to scroll. Near the end of a list the scroll clamps at its maximum, so the article settles wherever the leftover height allows and the rest of the view is dead space.

Not specific to `k` — `j`, `n`, `p` and clicking a header all end the same way. A short list shows it almost immediately; a long list only at the bottom, which is why it reads as intermittent.

## Measurements

Live FreshRSS 1.29.x, 11-article list, 1700x960, header target 77px in the restructured `search_bar` layout.

| | unfixed | fixed |
|---|---|---|
| `search_bar`, 20 openings (10 × `j`, 10 back × `k`) | 5 landed at 135 / 223 / 257 / 266 / 342px, each with `scrollTop == scrollHeight - clientHeight` | 20/20 at 76-77px |
| `control_bar` (page scroller), 20 openings | — | 20/20 at 34px |

The unfixed fingerprint repeated identically across three separate runs, so it is deterministic rather than a timing artefact.

## Why a whole viewport

The worst case is a zero-height article last in the list, which needs exactly the viewport height behind it to reach the top. The space is only reachable by scrolling past the final article, so it costs nothing until you are there. `#stream` is the last child of the scrolling element in both arrangements — `#rv-content` in `search_bar`, the page itself everywhere else — so one rule covers both.

Version bumped 0.3.1 → 0.3.2; without it the fix never reaches anyone who already has the extension.

Reported by @pax0707.