### PR TITLE
feat(right-click-actions): star articles like this

### DIFF
--- a/xExtension-RightClickActions/Controllers/rcafilterController.php
+++ b/xExtension-RightClickActions/Controllers/rcafilterController.php
@@ -3,6 +3,23 @@ declare(strict_types=1);
 
 final class FreshExtension_rcafilter_Controller extends Minz_ActionController {
 
+    /**
+     * Filter actions this controller will write. FreshRSS applies all three
+     * (read, star, label) from FilterActionsTrait regardless of owner, but its
+     * own subscription page only ever writes 'read' — so a feed-level star
+     * filter works and is simply not reachable through stock UI.
+     */
+    private const ACTIONS = ['read', 'star'];
+
+    /**
+     * Ceiling on the retroactive sweep. The read path delegates to
+     * markReadFeed(), which is a single UPDATE and needs no cap; starring has
+     * no search-scoped equivalent, so it collects ids first and that list is
+     * what has to stay bounded. Reported to the user when it bites rather than
+     * silently truncated.
+     */
+    private const RETRO_LIMIT = 1000;
+
     public function firstAction(): void {
         if (!FreshRSS_Auth::hasAccess()) {
             $this->sendJson(['error' => 'Unauthorized'], 403);
@@ -19,9 +36,18 @@ final class FreshExtension_rcafilter_Controller extends Minz_ActionController {
 
         $feedId = Minz_Request::paramInt('id');
         $filter = trim(Minz_Request::paramString('filter'));
+        // Absent means 'read': older callers posted no action at all, and the
+        // hide-articles menu item is still the common case.
+        $action = Minz_Request::paramString('action');
+        if ($action === '') {
+            $action = 'read';
+        }
 
         if ($feedId === 0 || $filter === '') {
             $this->sendJson(['error' => 'Missing id or filter'], 400);
+        }
+        if (!in_array($action, self::ACTIONS, true)) {
+            $this->sendJson(['error' => 'Unsupported action: ' . $action], 400);
         }
 
         $feedDAO = FreshRSS_Factory::createFeedDao();
@@ -30,35 +56,79 @@ final class FreshExtension_rcafilter_Controller extends Minz_ActionController {
             $this->sendJson(['error' => 'Feed not found'], 404);
         }
 
-        // Get existing read filters, append new one
+        // Compare and store the parsed form, not the raw string. FreshRSS only
+        // quotes a value that needs it (Search::quote() checks for spaces and
+        // separators), so the `intitle:"Boeing"` posted from the menu comes back
+        // out of toString() as `intitle:Boeing`. Comparing raw against
+        // re-serialised would miss that as a duplicate and append the same rule
+        // on every use. Existing entries are already normalised — they are read
+        // back through toString() here and saved in that form.
+        $search = new FreshRSS_BooleanSearch($filter);
+        $normalized = $search->toString();
+
         $existing = [];
-        foreach ($feed->filtersAction('read') as $booleanSearch) {
+        foreach ($feed->filtersAction($action) as $booleanSearch) {
             $existing[] = $booleanSearch->toString();
         }
 
-        if (in_array($filter, $existing, true)) {
+        if (in_array($normalized, $existing, true)) {
             $this->sendJson(['success' => true, 'message' => 'Filter already exists']);
             return;
         }
 
-        $existing[] = $filter;
-        $feed->_filtersAction('read', $existing);
+        $existing[] = $normalized;
+        $feed->_filtersAction($action, $existing);
 
         $ok = $feedDAO->updateFeed($feedId, ['attributes' => $feed->attributes()]);
         if ($ok === false) {
             $this->sendJson(['error' => 'Failed to save feed'], 500);
         }
 
-        // Mark existing matching articles as read
-        $entryDAO = FreshRSS_Factory::createEntryDao();
-        $search = new FreshRSS_BooleanSearch($filter);
-        $marked = $entryDAO->markReadFeed($feedId, uTimeString(), $search);
+        // A saved filter only runs against articles fetched from here on, so
+        // apply it once to what is already stored — otherwise the rule appears
+        // to do nothing until the next refresh.
+        [$affected, $capped] = $action === 'star'
+            ? $this->starExisting($feedId, $search)
+            : $this->readExisting($feedId, $search);
 
+        $verb = $action === 'star' ? 'starred' : 'marked read';
         $msg = 'Filter added';
-        if ($marked !== false && $marked > 0) {
-            $msg .= ', ' . $marked . ' existing article' . ($marked === 1 ? '' : 's') . ' marked read';
+        if ($affected > 0) {
+            $msg .= ', ' . $affected . ' existing article' . ($affected === 1 ? '' : 's') . ' ' . $verb;
+        }
+        // Reported whether or not anything changed: hitting the cap with zero
+        // changes means every one of those matches was already starred, and
+        // there may still be older ones that are not.
+        if ($capped) {
+            $msg .= ' (limited to the ' . self::RETRO_LIMIT . ' most recent matches; re-run to continue)';
         }
         $this->sendJson(['success' => true, 'message' => $msg]);
+    }
+
+    /**
+     * @return array{0: int, 1: bool} count affected, and whether the cap was hit
+     */
+    private function readExisting(int $feedId, FreshRSS_BooleanSearch $search): array {
+        $entryDAO = FreshRSS_Factory::createEntryDao();
+        $marked = $entryDAO->markReadFeed($feedId, uTimeString(), $search);
+        return [$marked === false ? 0 : $marked, false];
+    }
+
+    /**
+     * There is no markFavoriteFeed() to mirror markReadFeed() — markFavorite()
+     * takes ids — so collect the matching ids first. Passing an explicit limit
+     * matters: listIdsWhere() defaults to 1.
+     *
+     * @return array{0: int, 1: bool} count affected, and whether the cap was hit
+     */
+    private function starExisting(int $feedId, FreshRSS_BooleanSearch $search): array {
+        $entryDAO = FreshRSS_Factory::createEntryDao();
+        $ids = $entryDAO->listIdsWhere('f', $feedId, FreshRSS_Entry::STATE_ALL, $search, limit: self::RETRO_LIMIT);
+        if ($ids === null || $ids === []) {
+            return [0, false];
+        }
+        $starred = $entryDAO->markFavorite($ids, true);
+        return [$starred === false ? 0 : $starred, count($ids) >= self::RETRO_LIMIT];
     }
 
     private function sendJson(array $data, int $status = 200): never {

--- a/xExtension-RightClickActions/README.md
+++ b/xExtension-RightClickActions/README.md
@@ -7,6 +7,9 @@ Adds context menus to articles, feeds, and categories in FreshRSS.
 ## Features
 
 - Right-click article headlines to toggle read/unread, star, open in new tab, or filter
+- Build a standing rule from an article you are looking at: **Hide articles like this** and
+  **Star articles like this** save a title filter on that feed, then apply it to the articles
+  already stored so the rule is not invisible until the next refresh
 - Right-click sidebar feeds to mark all read/unread or open feed settings
 - Right-click sidebar categories to manage subscriptions, expand/collapse, or bulk-mark
 - Each context zone (headlines, article body, sidebar feeds, sidebar categories) can be toggled independently
@@ -20,10 +23,25 @@ Copy the `xExtension-RightClickActions` directory into your FreshRSS `extensions
 
 Four context zones, each independently togglable:
 
-- **Article headlines** -- toggle read, star, open in new tab, mark older/newer, filter by title or feed
+- **Article headlines** -- toggle read, star, open in new tab, mark older/newer, hide or star by title keyword, show this feed only
 - **Article content** -- same actions as headlines, applied to the article body area
 - **Sidebar feeds** -- mark all read/unread, recently read, open settings
 - **Sidebar categories** -- mark all read/unread, recently read, expand/collapse, add/manage subscriptions
+
+## Title filters
+
+Both title actions prompt with the article's title pre-filled, so you can cut it down to the
+part that should match. The result is saved as a filter action on that feed — `intitle:"…"`,
+quoted, because FreshRSS reads an unquoted `intitle:two words` as `intitle:two` plus a loose
+search for `words`.
+
+Filter actions normally only run against articles as they are fetched, so both actions also
+apply the rule once to articles already stored in that feed: hiding marks them read, starring
+stars them (up to the 1000 most recent, and it says so when it hits that).
+
+Feed-level star filters are not reachable from stock FreshRSS — its subscription page only
+writes the read filter — but the engine applies read, star and label filters from any owner,
+so the rule behaves exactly like a built-in one.
 
 ## Compatibility
 

--- a/xExtension-RightClickActions/configure.phtml
+++ b/xExtension-RightClickActions/configure.phtml
@@ -11,12 +11,12 @@ $actionGroups = [
     'header' => [
         '' => ['toggle_read', 'star_toggle', 'open_new_tab'],
         'Bulk actions' => ['mark_older', 'mark_newer'],
-        'Filtering' => ['filter_title', 'filter_feed'],
+        'Filtering' => ['filter_title', 'filter_star', 'filter_feed'],
     ],
     'body' => [
         '' => ['toggle_read', 'star_toggle', 'open_new_tab'],
         'Bulk actions' => ['mark_older', 'mark_newer'],
-        'Filtering' => ['filter_title', 'filter_feed'],
+        'Filtering' => ['filter_title', 'filter_star', 'filter_feed'],
     ],
     'sidebar_feed' => [
         '' => ['mark_all_read', 'mark_all_unread', 'recently_read', 'open_settings'],
@@ -32,7 +32,8 @@ $actionLabels = [
     'open_new_tab' => 'Open in new tab',
     'mark_older' => 'Mark older as read/unread',
     'mark_newer' => 'Mark newer as read/unread',
-    'filter_title' => 'Filter by title keyword',
+    'filter_title' => 'Hide articles by title keyword',
+    'filter_star' => 'Star articles by title keyword',
     'filter_feed' => 'Show this feed only',
     'mark_all_read' => 'Mark all as read',
     'mark_all_unread' => 'Mark all as unread',

--- a/xExtension-RightClickActions/extension.php
+++ b/xExtension-RightClickActions/extension.php
@@ -16,6 +16,7 @@ class RightClickActionsExtension extends Minz_Extension {
                 'mark_older' => true,
                 'mark_newer' => true,
                 'filter_title' => true,
+                'filter_star' => true,
                 'filter_feed' => true,
             ],
             'body' => [
@@ -25,6 +26,7 @@ class RightClickActionsExtension extends Minz_Extension {
                 'mark_older' => false,
                 'mark_newer' => false,
                 'filter_title' => false,
+                'filter_star' => false,
                 'filter_feed' => false,
             ],
             'sidebar_feed' => [
@@ -65,8 +67,13 @@ class RightClickActionsExtension extends Minz_Extension {
         if (Minz_Request::isPost()) {
             $config = self::DEFAULTS;
 
+            // The form posts a hidden '0' before each checkbox's '1', and
+            // paramBoolean() reads both — same result as the old `=== '1'`,
+            // without Minz_Request::param(), which FreshRSS 1.29 deprecated and
+            // which emits a notice on every save (the defect reported against
+            // Sticky Reader in #14).
             foreach (array_keys($config['zones']) as $zone) {
-                $config['zones'][$zone] = Minz_Request::param('zone_' . $zone) === '1';
+                $config['zones'][$zone] = Minz_Request::paramBoolean('zone_' . $zone);
             }
 
             foreach ($config['actions'] as $zone => $actions) {
@@ -75,7 +82,7 @@ class RightClickActionsExtension extends Minz_Extension {
                     if (!$config['zones'][$zone]) {
                         $config['actions'][$zone][$action] = false;
                     } else {
-                        $config['actions'][$zone][$action] = Minz_Request::param('action_' . $zone . '_' . $action) === '1';
+                        $config['actions'][$zone][$action] = Minz_Request::paramBoolean('action_' . $zone . '_' . $action);
                     }
                 }
             }

--- a/xExtension-RightClickActions/metadata.json
+++ b/xExtension-RightClickActions/metadata.json
@@ -2,7 +2,7 @@
     "name": "Right-Click Actions",
     "author": "featurecreep-cron",
     "description": "Adds context menus to articles, feeds, and categories",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "entrypoint": "RightClickActions",
     "type": "user"
 }

--- a/xExtension-RightClickActions/static/script.js
+++ b/xExtension-RightClickActions/static/script.js
@@ -65,6 +65,7 @@
     { key: 'mark_newer', action: 'mark_newer_unread', icon: '\u2B06\uFE0F', label: 'Mark newer as unread' },
     { sep: true },
     { key: 'filter_title', icon: '\uD83D\uDEAB', label: 'Hide articles like this' },
+    { key: 'filter_star', icon: '\u2B50', label: 'Star articles like this' },
     { key: 'filter_feed', icon: '\uD83D\uDD0D', label: 'Show this feed only' }
   ];
 
@@ -138,11 +139,10 @@
       row.dataset.action = actionId;
 
       var actionLabel = item.label;
-      if (actionId === 'filter_title' && targetFlux) {
-        var titleEl = targetFlux.querySelector('.flux_header .title');
-        var text = titleEl ? titleEl.textContent.trim() : '';
+      if ((actionId === 'filter_title' || actionId === 'filter_star') && targetFlux) {
+        var text = articleTitleText(targetFlux);
         if (text.length > 40) text = text.substring(0, 40) + '\u2026';
-        actionLabel = 'Filter: ' + text;
+        actionLabel = (actionId === 'filter_star' ? 'Star: ' : 'Filter: ') + text;
       }
 
       var iconSpan = document.createElement('span');
@@ -206,6 +206,20 @@
     if ((makeRead && isUnread) || (!makeRead && !isUnread)) toggleRead(flux);
   }
 
+  function toggleStar(flux) {
+    var link = flux.querySelector('a.bookmark');
+    if (link) link.click();
+  }
+
+  // Safe to run after the server has already starred the same articles: the
+  // link carries the state it will set (is_favorite=1 while the row is
+  // unstarred), and this only clicks rows that still look unstarred, so a
+  // second pass sets true rather than toggling back to false.
+  function setStar(flux, makeStar) {
+    var isStarred = flux.classList.contains('favorite');
+    if ((makeStar && !isStarred) || (!makeStar && isStarred)) toggleStar(flux);
+  }
+
   function getOlderNewer(fluxes, idx) {
     var before = [];
     var after = [];
@@ -233,11 +247,12 @@
     };
   }
 
-  function addPermanentFilter(feedId, filter) {
+  function addPermanentFilter(feedId, filter, action) {
     var csrfToken = (context.extensions && context.extensions['Right-Click Actions'] && context.extensions['Right-Click Actions'].csrf) || '';
     var fd = new FormData();
     fd.append('id', feedId);
     fd.append('filter', filter);
+    fd.append('action', action || 'read');
     fd.append('_csrf', csrfToken);
 
     fetch('./?c=rcafilter&a=add', {
@@ -251,6 +266,66 @@
         else showNotification(data.error || 'Unknown error', true);
       })
       .catch(function (err) { showNotification('Error: ' + err, true); });
+  }
+
+  // FreshRSS reads a bare `intitle:two words` as intitle:two AND a loose
+  // "words", so a keyword lifted from an article title — which is exactly what
+  // the prompt pre-fills — has to be quoted or the saved rule matches far more
+  // than the user asked for. Mirrors QuickFilterService::buildFilterString().
+  function buildTitleFilter(keyword) {
+    return 'intitle:"' + keyword.replace(/"/g, '\\"') + '"';
+  }
+
+  // The title anchor is not only the title: FreshRSS nests its inline
+  // <span class="author"> inside it, and other extensions inject controls in
+  // there too — with QuickFilter installed, .textContent reads
+  // "Wednesday assorted links Tyler Cowen☆✓". Taking just the anchor's own text
+  // nodes leaves the title, whoever else has written into the element.
+  function articleTitleText(flux) {
+    var a = flux.querySelector('.flux_header a.item-element.title') || flux.querySelector('.title');
+    if (!a) return '';
+    var text = '';
+    Array.prototype.forEach.call(a.childNodes, function (n) {
+      if (n.nodeType === Node.TEXT_NODE) text += n.textContent;
+    });
+    text = text.trim();
+    return text || a.textContent.trim();
+  }
+
+  var FILTER_PROMPTS = {
+    read: 'Hide articles with titles containing:',
+    star: 'Star articles with titles containing:'
+  };
+
+  function filterOnTitle(action, fluxes) {
+    var articleTitle = articleTitleText(targetFlux);
+    var feedId = targetFlux.dataset.feed;
+
+    var keyword = prompt(FILTER_PROMPTS[action], articleTitle);
+    if (keyword === null) return;
+    keyword = keyword.trim();
+    if (!keyword || !feedId) return;
+
+    addPermanentFilter(feedId, buildTitleFilter(keyword), action);
+
+    // Apply it to what is already on screen. The server pass covers the rest of
+    // the feed but cannot touch this page's DOM. Scoped to the same feed as the
+    // saved rule — matching titles in other feeds are not what was asked for,
+    // and the rule will never act on them again.
+    var lower = keyword.toLowerCase();
+    var matched = 0;
+    fluxes.forEach(function (f) {
+      if (f.dataset.feed !== feedId) return;
+      if (articleTitleText(f).toLowerCase().indexOf(lower) !== -1) {
+        if (action === 'star') setStar(f, true);
+        else setRead(f, true);
+        matched++;
+      }
+    });
+    if (matched > 0) {
+      showNotification(matched + ' article' + (matched === 1 ? '' : 's') +
+        (action === 'star' ? ' starred' : ' marked read') + ' on page');
+    }
   }
 
   // ---------- Sidebar helpers ----------
@@ -369,23 +444,10 @@
         showNotification(ranges.newer.length + ' articles marked unread');
         break;
       case 'filter_title':
-        var titleEl = targetFlux.querySelector('.title');
-        var articleTitle = titleEl ? titleEl.textContent.trim() : '';
-        var feedId = targetFlux.dataset.feed;
-        var keyword = prompt('Filter articles with titles containing:', articleTitle);
-        if (!keyword || !feedId) break;
-        addPermanentFilter(feedId, 'intitle:' + keyword);
-        // Also mark matching articles on the current page as read
-        var lower = keyword.toLowerCase();
-        var matched = 0;
-        fluxes.forEach(function (f) {
-          var t = f.querySelector('.title');
-          if (t && t.textContent.toLowerCase().includes(lower)) {
-            setRead(f, true);
-            matched++;
-          }
-        });
-        if (matched > 0) showNotification(matched + ' articles marked read on page');
+        filterOnTitle('read', fluxes);
+        break;
+      case 'filter_star':
+        filterOnTitle('star', fluxes);
         break;
       case 'filter_feed':
         var feedLink = targetFlux.querySelector('.flux_header a[href*="get=f_"]');


### PR DESCRIPTION
Right-click an article → **Star articles like this**. Prompts with the title pre-filled, saves an `intitle:` filter on that feed, and applies it to what is already stored.

The menu could already do this in one direction — "Hide articles like this" — but `rcafilterController` hardcoded `'read'`. This takes the literal out so one path writes either action.

## Why it works at all

FreshRSS applies `read`, `star` and `label` filters from any owner (`FilterActionsTrait::applyFilterActions()`), but its subscription page only ever writes the read box (`subscriptionController.php:254`). A feed-level star filter is therefore fully supported by the engine and simply unreachable from stock UI.

There is no `markFavoriteFeed()` to mirror `markReadFeed()` — `markFavorite()` takes ids — so the retroactive pass collects matching ids via `listIdsWhere()` (explicit limit: it defaults to **1**) and bounds them at 1000, saying so in the response when the cap bites.

## Three defects in the existing hide action, fixed for both

1. **The saved filter was unquoted.** The prompt pre-fills the article title, so the common case wrote `intitle:several words` — which FreshRSS parses as `intitle:several` AND a loose search for the rest. Now quoted and escaped, matching what `QuickFilterService` already did.
2. **The title was read with `.textContent`, which is not the title.** FreshRSS nests its inline `<span class="author">` inside the title anchor, and other extensions inject into it. Measured on a live instance with QuickFilter installed, the prompt pre-filled `Wednesday assorted links Tyler Cowen☆✓`. Reading only the anchor's own text nodes gives `Wednesday assorted links` — verified across 11 articles, none empty, none polluted.
3. **The duplicate check never fired for single-word filters.** `Search::quote()` only quotes values containing spaces or separators, so `intitle:"Boeing"` returns from `toString()` as `intitle:Boeing`; comparing the posted string against re-serialised stored ones missed it and appended the same rule on every use. Both sides now compare in parsed form.

Also: the on-page sweep is scoped to the same feed as the saved rule (it previously marked matching titles read in *other* feeds, which the rule will never act on), and `handleConfigureAction` moves off `Minz_Request::param()` — deprecated in 1.29 and the source of the notices reported against Sticky Reader in #14.

## Verification

Client logic exercised against a live FreshRSS 1.29.x instance: title extraction across 11 articles, filter-string construction including embedded quotes, and the feed-scoped sweep predicate. `node --check` clean.

**Not verified end-to-end:** the controller cannot run without deploying the extension, so the server write, the retroactive star pass and the cap message have been reasoned against upstream source, not executed. Worth a live test before relying on it.

Version bumped 0.1.6 → 0.1.7.