### PR TITLE
feat(extmgr): install from a specific branch, and show which one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,20 @@
 name: CI
 
+# No branch filters. Gating on [main] meant PHP was only ever linted *after*
+# merge: pull_request runs had fired exactly twice in the repo's history, both
+# from Dependabot, so every hand-authored change reached main unlinted. Running
+# on every push and every pull request is what makes this a gate rather than a
+# post-mortem.
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   php-lint:

--- a/xExtension-ExtensionManager/Controllers/extmgrController.php
+++ b/xExtension-ExtensionManager/Controllers/extmgrController.php
@@ -35,14 +35,20 @@ final class FreshExtension_extmgr_Controller extends Minz_ActionController {
                 $this->sendJson(['error' => 'Catalog session expired. Refresh the page and try again.'], 400);
             }
 
+            // Where this catalog was fetched from, so the install can be labelled
+            // with its branch afterwards.
+            $entry = ExtensionManagerExtension::getCatalogEntry($catalogToken);
+            $srcUrl = $entry['url'] ?? null;
+            $srcBranch = $entry['branch'] ?? null;
+
             if (ExtensionManagerExtension::extensionsWritable()) {
-                $result = ExtensionManagerExtension::installFromExtracted($tmpDir, $dir);
+                $result = ExtensionManagerExtension::installFromExtracted($tmpDir, $dir, $srcUrl, $srcBranch);
                 if ($result === true) {
                     $this->sendJson(['success' => true, 'message' => $dir . ' installed successfully']);
                 }
                 $this->sendJson(['error' => is_string($result) ? $result : 'Unknown error'], 500);
             } else {
-                $result = ExtensionManagerExtension::queueInstall($tmpDir, $dir);
+                $result = ExtensionManagerExtension::queueInstall($tmpDir, $dir, $srcUrl, $srcBranch);
                 if ($result === true) {
                     $this->sendJson([
                         'success' => true,

--- a/xExtension-ExtensionManager/README.md
+++ b/xExtension-ExtensionManager/README.md
@@ -48,6 +48,24 @@ Refresh FreshRSS in your browser after running.
 
 Settings → Extensions → Extension Manager → Configure. Add GitHub repository URLs (one per line) as extension sources.
 
+### Tracking a branch
+
+Append `/tree/<branch>` to install from somewhere other than the repository's default branch:
+
+```
+https://github.com/user/repo
+https://github.com/user/repo/tree/develop
+https://github.com/user/repo/tree/fix/some-bug
+```
+
+That is the URL GitHub shows in the address bar when you switch branches, so it can be pasted directly. Branch names containing slashes work.
+
+The same repository may be listed more than once on different branches. Each gets its own section on the Extensions page, labelled with the branch, so it is clear which one an Install button will use.
+
+Only one copy of a given extension can be installed at a time. When the installed copy came from a different branch than the section you are looking at, the Installed column shows that branch next to the version — so a build from `develop` is never mistaken for one from `main`.
+
+A branch that does not exist is reported as an error. It is never silently replaced with the default branch, because that would install code you did not ask for and report success.
+
 ## Compatibility
 
 Requires FreshRSS 1.20+.

--- a/xExtension-ExtensionManager/configure.phtml
+++ b/xExtension-ExtensionManager/configure.phtml
@@ -3,7 +3,18 @@
 
     <div class="form-group">
         <label for="repos">Extension repositories</label>
-        <p class="help">One GitHub repository URL per line. Extensions from these repos will appear on the Extensions page.</p>
+        <p class="help">
+            One GitHub repository URL per line. Extensions from these repos will appear on the Extensions page.
+        </p>
+        <p class="help">
+            To track a branch instead of the default, add <code>/tree/&lt;branch&gt;</code> — the URL GitHub
+            shows when you switch branches, so you can paste it straight in. The same repository can be listed
+            more than once on different branches; each gets its own section, labelled with the branch.
+        </p>
+        <p class="help">
+            <code>https://github.com/user/repo</code><br>
+            <code>https://github.com/user/repo/tree/develop</code>
+        </p>
         <textarea id="repos" name="repos" rows="4" cols="60" placeholder="https://github.com/user/repo"><?= htmlspecialchars(implode("\n", $this->getUserConfigurationValue('repos') ?: [])) ?></textarea>
     </div>
 

--- a/xExtension-ExtensionManager/extension.php
+++ b/xExtension-ExtensionManager/extension.php
@@ -3,6 +3,13 @@
 class ExtensionManagerExtension extends Minz_Extension {
 
     /**
+     * Sidecar file recording which repository and branch an extension was
+     * installed from. Lets the Extensions page distinguish two installs of the
+     * same extension that came from different branches.
+     */
+    private const SOURCE_MARKER = '.extmgr-source.json';
+
+    /**
      * Queue directory for deferred installs (within FreshRSS data dir).
      * Used when the extensions directory is not writable at runtime.
      */
@@ -61,9 +68,17 @@ class ExtensionManagerExtension extends Minz_Extension {
             if (file_exists($metaFile)) {
                 $meta = json_decode(file_get_contents($metaFile), true);
                 if ($meta) {
+                    $marker = self::readSourceMarker($dir);
                     $installed[basename($dir)] = [
                         'name' => $meta['name'] ?? basename($dir),
                         'version' => $meta['version'] ?? '0',
+                        // null for hand-installed extensions and anything
+                        // installed before Extension Manager recorded this.
+                        'source' => $marker['url'] ?? null,
+                        'branch' => $marker['branch'] ?? null,
+                        'sourceLabel' => $marker
+                            ? self::sourceLabel($marker['url'], $marker['branch'] ?? null)
+                            : null,
                     ];
                 }
             }
@@ -79,7 +94,7 @@ class ExtensionManagerExtension extends Minz_Extension {
      * Store a catalog tmpDir in the PHP session, keyed by a random token.
      * Returns the token for client reference.
      */
-    private static function storeCatalogSession(string $tmpDir): string {
+    private static function storeCatalogSession(string $tmpDir, ?string $url = null, ?string $branch = null): string {
         if (session_status() !== PHP_SESSION_ACTIVE) {
             @session_start();
         }
@@ -89,6 +104,8 @@ class ExtensionManagerExtension extends Minz_Extension {
         }
         $_SESSION['extmgr_catalogs'][$token] = [
             'tmpDir' => $tmpDir,
+            'url' => $url,
+            'branch' => $branch,
             'created' => time(),
         ];
         // Expire old entries (> 30 minutes)
@@ -125,6 +142,55 @@ class ExtensionManagerExtension extends Minz_Extension {
         return $entry['tmpDir'];
     }
 
+    /**
+     * Full catalog session entry — tmpDir plus the source it was fetched from.
+     * Returns null if not found or expired. Unlike getCatalogSession() this does
+     * not clean up on expiry; call that first if you need both.
+     */
+    public static function getCatalogEntry(string $token): ?array {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $entry = $_SESSION['extmgr_catalogs'][$token] ?? null;
+        if (!is_array($entry) || time() - $entry['created'] > 1800) {
+            return null;
+        }
+        return $entry;
+    }
+
+    /**
+     * Record where an installed extension came from, as a sidecar file inside
+     * the extension directory. Written into the *source* tree before the copy,
+     * so both the direct and queued install paths carry it along without either
+     * needing to know about it.
+     *
+     * A dotfile: FreshRSS only looks for metadata.json and extension.php, and
+     * getInstalledExtensions() globs xExtension-* directories, so this is inert.
+     */
+    private static function writeSourceMarker(string $dir, ?string $url, ?string $branch): void {
+        if ($url === null) {
+            return;
+        }
+        @file_put_contents($dir . '/' . self::SOURCE_MARKER, json_encode([
+            'url' => $url,
+            'branch' => $branch,
+            'installed' => gmdate('c'),
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * Read the sidecar written by writeSourceMarker(). Null when the extension
+     * was installed by hand or by an older Extension Manager.
+     */
+    private static function readSourceMarker(string $dir): ?array {
+        $file = $dir . '/' . self::SOURCE_MARKER;
+        if (!file_exists($file)) {
+            return null;
+        }
+        $data = json_decode((string) file_get_contents($file), true);
+        return is_array($data) && isset($data['url']) ? $data : null;
+    }
+
     // ---------------------------------------------------------------
     // Queue mode: deferred installs via FreshRSS data directory
     // ---------------------------------------------------------------
@@ -134,7 +200,7 @@ class ExtensionManagerExtension extends Minz_Extension {
      * Copies the extension source to DATA_PATH/extmgr/queue/{dirName}/
      * and writes a manifest entry.
      */
-    public static function queueInstall(string $tmpDir, string $extDirName): string|bool {
+    public static function queueInstall(string $tmpDir, string $extDirName, ?string $url = null, ?string $branch = null): string|bool {
         $extDirName = basename($extDirName);
 
         if ($extDirName === 'xExtension-ExtensionManager') {
@@ -150,6 +216,10 @@ class ExtensionManagerExtension extends Minz_Extension {
         if (!file_exists($sourceDir . '/metadata.json') || !file_exists($sourceDir . '/extension.php')) {
             return 'Extension is missing required files (metadata.json or extension.php)';
         }
+
+        // Written before the copy so it travels into the queue and out again
+        // when install-queued.sh moves the directory into place.
+        self::writeSourceMarker($sourceDir, $url, $branch);
 
         $queueDir = self::queueDir() . '/queue';
         if (!is_dir($queueDir)) {
@@ -296,20 +366,81 @@ class ExtensionManagerExtension extends Minz_Extension {
      * Fetch the extension catalog from a GitHub repo.
      * Returns array with 'extensions', 'catalogToken' (session key), or 'error'.
      */
-    public static function fetchRepoCatalog($url) {
-        if (!preg_match('#^https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$#', $url)) {
-            return ['error' => 'Invalid URL: only GitHub repositories supported'];
+    /**
+     * Split a configured source into a repository URL and an optional branch.
+     *
+     * Accepted forms:
+     *   https://github.com/owner/repo                    → branch null (resolve main, then master)
+     *   https://github.com/owner/repo/tree/develop        → branch "develop"
+     *   https://github.com/owner/repo/tree/fix/some-bug   → branch "fix/some-bug"
+     *
+     * The /tree/ form is what GitHub puts in the address bar when you switch
+     * branches, so it can be pasted straight in. Branch names may contain
+     * slashes, so everything after /tree/ is the branch.
+     *
+     * Returns ['url' => string, 'branch' => ?string], or null if not a GitHub URL.
+     */
+    public static function parseSource(string $source): ?array {
+        $source = trim($source);
+        $source = rtrim($source, '/');
+
+        if (!preg_match('#^(https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+?)(?:\.git)?(?:/tree/(.+))?$#', $source, $m)) {
+            return null;
         }
 
-        $url = rtrim($url, '/');
-        $url = preg_replace('#\.git$#', '', $url);
-
-        $zipData = self::downloadZip($url . '/archive/refs/heads/main.zip');
-        if ($zipData === false) {
-            $zipData = self::downloadZip($url . '/archive/refs/heads/master.zip');
+        $branch = isset($m[2]) && $m[2] !== '' ? $m[2] : null;
+        if ($branch !== null && !self::isSafeBranch($branch)) {
+            return null;
         }
-        if ($zipData === false) {
-            return ['error' => 'Failed to download from ' . $url];
+
+        return ['url' => $m[1], 'branch' => $branch];
+    }
+
+    /**
+     * Branch names go into a URL path, so refuse traversal and anything that is
+     * not a plausible ref. Slashes are allowed — `fix/foo` is a normal branch.
+     */
+    private static function isSafeBranch(string $branch): bool {
+        if (strpos($branch, '..') !== false) {
+            return false;
+        }
+        return (bool) preg_match('#^[A-Za-z0-9][A-Za-z0-9._/-]*$#', $branch);
+    }
+
+    /**
+     * Human-readable label for a source, e.g. "owner/repo @ develop".
+     */
+    public static function sourceLabel(string $url, ?string $branch): string {
+        $label = preg_replace('#^https://github\.com/#', '', $url);
+        return $branch === null ? $label : $label . ' @ ' . $branch;
+    }
+
+    public static function fetchRepoCatalog($source) {
+        $parsed = self::parseSource($source);
+        if ($parsed === null) {
+            return ['error' => 'Invalid URL: expected https://github.com/owner/repo, optionally with /tree/branch'];
+        }
+
+        $url = $parsed['url'];
+        $branch = $parsed['branch'];
+
+        if ($branch !== null) {
+            // Explicit branch: no silent fallback. Falling back to main here
+            // would install code the user did not ask for and report success.
+            $zipData = self::downloadZip($url . '/archive/refs/heads/' . $branch . '.zip');
+            if ($zipData === false) {
+                return ['error' => 'Branch "' . $branch . '" not found in ' . $url];
+            }
+        } else {
+            $branch = 'main';
+            $zipData = self::downloadZip($url . '/archive/refs/heads/main.zip');
+            if ($zipData === false) {
+                $branch = 'master';
+                $zipData = self::downloadZip($url . '/archive/refs/heads/master.zip');
+            }
+            if ($zipData === false) {
+                return ['error' => 'Failed to download from ' . $url];
+            }
         }
 
         $tmpFile = tempnam(sys_get_temp_dir(), 'frss_ext_');
@@ -341,6 +472,8 @@ class ExtensionManagerExtension extends Minz_Extension {
                     'description' => $meta['description'] ?? '',
                     'author' => $meta['author'] ?? '',
                     'url' => $url,
+                    'branch' => $branch,
+                    'label' => self::sourceLabel($url, $branch),
                 ];
             }
         }
@@ -350,8 +483,9 @@ class ExtensionManagerExtension extends Minz_Extension {
             return ['error' => 'No extensions found in repository'];
         }
 
-        // Store tmpDir in session instead of sending to client
-        $catalogToken = self::storeCatalogSession($tmpDir);
+        // Store tmpDir in session instead of sending to client. The source is
+        // stored with it so an install can record where the code came from.
+        $catalogToken = self::storeCatalogSession($tmpDir, $url, $branch);
 
         return ['extensions' => $catalog, 'catalogToken' => $catalogToken];
     }
@@ -401,7 +535,7 @@ class ExtensionManagerExtension extends Minz_Extension {
      * Install a single extension by directory name from an already-extracted repo.
      * Returns true on success, or an error string on failure.
      */
-    public static function installFromExtracted($tmpDir, $extDirName): string|bool {
+    public static function installFromExtracted($tmpDir, $extDirName, ?string $url = null, ?string $branch = null): string|bool {
         // Sanitize: strip any path components
         $extDirName = basename($extDirName);
 
@@ -426,6 +560,9 @@ class ExtensionManagerExtension extends Minz_Extension {
         if (!file_exists($sourceDir . '/metadata.json') || !file_exists($sourceDir . '/extension.php')) {
             return 'Extension is missing required files (metadata.json or extension.php)';
         }
+
+        // Written before the copy so it travels with the files.
+        self::writeSourceMarker($sourceDir, $url, $branch);
 
         $extPath = dirname(dirname(__FILE__));
         $targetDir = $extPath . '/' . $extDirName;
@@ -487,11 +624,15 @@ class ExtensionManagerExtension extends Minz_Extension {
      * Install directly from a GitHub URL (single-extension repos, community table).
      */
     public static function downloadAndInstall($url, $extName = null) {
-        // Handle tree URLs: https://github.com/user/repo/tree/branch/xExtension-Foo
+        // Handle deep tree URLs pointing at one extension inside a repo:
+        //   https://github.com/owner/repo/tree/<branch>/xExtension-Foo
+        // The branch is kept and passed through to fetchRepoCatalog() — it used
+        // to be matched and thrown away, so every such URL silently installed
+        // main regardless of the branch the user pasted.
         $targetExtDir = null;
-        if (preg_match('#^(https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)/tree/[^/]+/(xExtension-[a-zA-Z0-9._-]+)$#', $url, $matches)) {
-            $url = $matches[1];
-            $targetExtDir = $matches[2];
+        if (preg_match('#^(https://github\.com/[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)/tree/(.+)/(xExtension-[a-zA-Z0-9._-]+)$#', $url, $matches)) {
+            $url = $matches[1] . '/tree/' . $matches[2];
+            $targetExtDir = $matches[3];
         }
 
         $result = self::fetchRepoCatalog($url);
@@ -539,10 +680,12 @@ class ExtensionManagerExtension extends Minz_Extension {
         }
 
         // Decide mode: immediate install or queue
+        $srcUrl = $extToInstall['url'] ?? null;
+        $srcBranch = $extToInstall['branch'] ?? null;
         if (self::extensionsWritable()) {
-            $installResult = self::installFromExtracted($tmpDir, $extToInstall['dir']);
+            $installResult = self::installFromExtracted($tmpDir, $extToInstall['dir'], $srcUrl, $srcBranch);
         } else {
-            $installResult = self::queueInstall($tmpDir, $extToInstall['dir']);
+            $installResult = self::queueInstall($tmpDir, $extToInstall['dir'], $srcUrl, $srcBranch);
         }
         self::recursiveDelete($tmpDir);
         return $installResult;

--- a/xExtension-ExtensionManager/metadata.json
+++ b/xExtension-ExtensionManager/metadata.json
@@ -2,7 +2,7 @@
     "name": "Extension Manager",
     "author": "featurecreep-cron",
     "description": "Install, update, and remove extensions from the settings page",
-    "version": "0.4.3",
+    "version": "0.5.0",
     "entrypoint": "ExtensionManager",
     "type": "user"
 }

--- a/xExtension-ExtensionManager/static/script.js
+++ b/xExtension-ExtensionManager/static/script.js
@@ -184,7 +184,7 @@
 
     var input = document.createElement('input');
     input.type = 'url';
-    input.placeholder = 'https://github.com/user/repo';
+    input.placeholder = 'https://github.com/user/repo  (or .../tree/branch)';
     input.className = 'ext-mgr-url-input';
 
     var btn = document.createElement('button');
@@ -195,8 +195,10 @@
     btn.addEventListener('click', function () {
       var url = input.value.trim();
       if (!url) return;
-      if (!/^https:\/\/github\.com\/[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(url)) {
-        showNotification('Only GitHub repository URLs are supported', true);
+      // Optional /tree/<branch>; branch names may contain slashes (fix/foo).
+      // Mirrors parseSource() in extension.php — keep the two in step.
+      if (!/^https:\/\/github\.com\/[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+(\/tree\/[A-Za-z0-9][A-Za-z0-9._/-]*)?$/.test(url)) {
+        showNotification('Expected https://github.com/owner/repo, optionally with /tree/branch', true);
         return;
       }
 
@@ -254,6 +256,18 @@
     main.appendChild(container);
   }
 
+  /**
+   * "https://github.com/owner/repo/tree/fix/foo" -> {repo: "owner/repo", branch: "fix/foo"}
+   * Mirrors parseSource() in extension.php.
+   */
+  function splitSource(url) {
+    var m = /^https:\/\/github\.com\/([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)(?:\/tree\/(.+))?$/.exec(
+      String(url).replace(/\/+$/, '')
+    );
+    if (!m) return { repo: String(url).replace('https://github.com/', ''), branch: null };
+    return { repo: m[1], branch: m[2] || null };
+  }
+
   function loadSingleRepoCatalog(repoUrl) {
     var main = document.querySelector('.post') || document.querySelector('#content') || document.body;
 
@@ -261,7 +275,19 @@
     section.className = 'ext-mgr-repo-section';
 
     var heading = document.createElement('h3');
-    heading.textContent = repoUrl.replace('https://github.com/', '');
+    var parts = splitSource(repoUrl);
+    heading.textContent = parts.repo;
+    if (parts.branch) {
+      // Two sources can differ only by branch, so the branch has to be visible
+      // on the heading — otherwise the page shows the same extension twice with
+      // no way to tell which table installs what.
+      var tag = document.createElement('span');
+      tag.className = 'ext-mgr-branch';
+      tag.textContent = parts.branch;
+      tag.title = 'Branch: ' + parts.branch;
+      heading.appendChild(document.createTextNode(' '));
+      heading.appendChild(tag);
+    }
     section.appendChild(heading);
 
     var loading = document.createElement('p');
@@ -467,6 +493,8 @@
       installedByName[installed[dir].name] = {
         dir: dir,
         version: String(installed[dir].version),
+        branch: installed[dir].branch || null,
+        source: installed[dir].source || null,
       };
     }
 
@@ -481,6 +509,17 @@
 
       var tdInstalled = document.createElement('td');
       tdInstalled.textContent = info ? info.version : '';
+      // Only one copy of a given extension can be installed at a time, so when
+      // the installed copy came from a different branch than this table, say so
+      // — otherwise both tables claim the same version and neither is wrong.
+      if (info && info.branch && info.branch !== ext.branch) {
+        var from = document.createElement('span');
+        from.className = 'ext-mgr-branch ext-mgr-branch-other';
+        from.textContent = info.branch;
+        from.title = 'Installed from ' + (info.source || '') + ' @ ' + info.branch;
+        tdInstalled.appendChild(document.createTextNode(' '));
+        tdInstalled.appendChild(from);
+      }
       tr.appendChild(tdInstalled);
 
       var tdVersion = document.createElement('td');

--- a/xExtension-ExtensionManager/static/style.css
+++ b/xExtension-ExtensionManager/static/style.css
@@ -177,3 +177,22 @@
     font-size: 0.9em;
     opacity: 0.8;
 }
+
+/* Branch badge — distinguishes two sources that differ only by branch, and
+   flags when the installed copy came from a branch other than this table's. */
+.ext-mgr-branch {
+    display: inline-block;
+    padding: 0.05em 0.45em;
+    border: 1px solid currentColor;
+    border-radius: 0.75em;
+    font-size: 0.75em;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    vertical-align: middle;
+    opacity: 0.8;
+}
+
+.ext-mgr-branch-other {
+    font-weight: 500;
+    opacity: 0.65;
+}


### PR DESCRIPTION
Rebased onto current main (was based on `dac0ba5`, July 15). Clean rebase, no conflicts.

## What it fixes

Extension Manager accepted `/tree/<branch>/` URLs, matched the branch with a non-capturing group, and threw it away — every such URL silently installed `main`. Pointing it at a develop branch installed the unpatched code and reported success, which is the worst available failure mode.

Sources now take an optional `/tree/<branch>` suffix — the URL GitHub shows when you switch branches, so it can be pasted straight in. Branch names with slashes work. **A branch that does not exist is an error, never a silent fallback to main.**

Distinguishing installs:
- each source gets its own section headed `owner/repo` with a branch badge
- installs record their origin in a `.extmgr-source.json` sidecar, written into the source tree before the copy so the direct and queued paths both carry it
- when the installed copy came from a different branch than the section being viewed, the Installed column shows that branch beside the version

Also drops the `[main]` branch filters in `ci.yml`. `pull_request` had fired twice ever, both Dependabot, so hand-authored PHP was reaching main unlinted.

## Security review

The branch name is interpolated into a download URL, so:

- **Validated by allowlist** — `^[A-Za-z0-9][A-Za-z0-9._/-]*$` with an explicit `..` rejection. No traversal, no CRLF, no `%`/`@`/`?`/`#`, and it cannot start with `//`, so it cannot escape the host.
- **Host is pinned** — the repo regex only accepts `https://github.com/owner/repo`, so there is no SSRF pivot.
- **Rendered with `textContent`**, never `innerHTML` — and the charset admits no markup anyway.

Minor, not blocking: the sidecar write uses `@file_put_contents`. Failure is silent, and degrades only the "installed from branch X" display.

## Verification

Running in production on a live FreshRSS 1.29.x instance and confirmed working — its extensions page reads a `develop` source and correctly showed `Right-Click Actions 0.1.7 develop` against `0.1.6` installed, which is how 0.1.7 was tested before merge.

Version bumped 0.4.3 → 0.5.0.