### PR TITLE
docs: correct the FreshRSS version these measurements were taken on

### DIFF
--- a/xExtension-RightClickActions/extension.php
+++ b/xExtension-RightClickActions/extension.php
@@ -69,9 +69,10 @@ class RightClickActionsExtension extends Minz_Extension {
 
             // The form posts a hidden '0' before each checkbox's '1', and
             // paramBoolean() reads both — same result as the old `=== '1'`,
-            // without Minz_Request::param(), which FreshRSS 1.29 deprecated and
-            // which emits a notice on every save (the defect reported against
-            // Sticky Reader in #14).
+            // without Minz_Request::param(), which upstream deprecated (the
+            // #[Deprecated] attribute is present as far back as 1.28.1) and which
+            // emits a notice on every save — the defect reported against Sticky
+            // Reader in #14, seen there on 1.29.2-dev.
             foreach (array_keys($config['zones']) as $zone) {
                 $config['zones'][$zone] = Minz_Request::paramBoolean('zone_' . $zone);
             }

--- a/xExtension-StickyReader/static/style.css
+++ b/xExtension-StickyReader/static/style.css
@@ -23,7 +23,7 @@
  * toolbar and the article list, which read as "the toolbar moved right" when in
  * fact the toolbar had not moved at all.
  *
- * Measured on FreshRSS 1.29.x / theme Origine: `.aside` position flips
+ * Measured on FreshRSS 1.28.1 / theme Origine: `.aside` position flips
  * fixed → static → fixed at viewport widths 737 / 1292 / 580 while its width
  * stays 284.323px throughout. Both halves of the mechanism.
  *
@@ -101,7 +101,7 @@
  * way once the remaining articles are shorter than the viewport, which is why a
  * short list shows it immediately and a long one only at the bottom.
  *
- * Measured on a live FreshRSS 1.29.x instance, 11-article list, 1700x960,
+ * Measured on a live FreshRSS 1.28.1 instance, 11-article list, 1700x960,
  * search_bar mode, target position 77px. Without trailing space five of ten
  * openings landed at 135, 223, 257, 266 and 342px, each with scrollTop already
  * equal to scrollHeight - clientHeight. With this rule, all twenty openings —


### PR DESCRIPTION
Comments in Sticky Reader and Right-Click Actions cited FreshRSS **1.29.x**. The instance every one of those measurements was taken on reports **1.28.1** — its own page context carries `"version":"1.28.1"`. I asserted the version rather than reading it, and it reached shipped code comments and two commit messages (#19, #20).

The measurements are unaffected — the aside overlay, the `contain: layout` stacking context and the end-of-list anchoring were each observed directly, and none depended on the version being 1.29.

Also drops "deprecated in 1.29" for `Minz_Request::param()`. The `#[Deprecated]` attribute is present in 1.28.1 too, so the comment now states what is verifiable: deprecated upstream, with the notice pax0707 reported seen on 1.29.2-dev.

Comment-only, no behaviour change — hence the `no-version-bump` label.