### PR TITLE
feat(extmgr): switch an installed extension between branch sources

### DIFF
--- a/xExtension-ExtensionManager/README.md
+++ b/xExtension-ExtensionManager/README.md
@@ -66,6 +66,14 @@ Only one copy of a given extension can be installed at a time. When the installe
 
 A branch that does not exist is reported as an error. It is never silently replaced with the default branch, because that would install code you did not ask for and report success.
 
+### Switching branches
+
+In a section whose branch is not the one the installed copy came from, the action is **Switch to `<branch>`** instead of Install or Update. It replaces the installed copy with that section's build and records the new origin, so testing from `develop` and returning to `main` is a single click in each direction.
+
+The switch is offered on the difference in origin, not on version order — you can move back to a branch that is behind the one you are on, which is the usual case after testing something on `develop`. Because that can be a downgrade, the button is coloured differently from Install and Update.
+
+An extension installed before source tracking existed has no recorded origin. Those keep the old behaviour — Update when a newer version is available — since an install that cannot be placed is not evidence that it came from somewhere else.
+
 ## Compatibility
 
 Requires FreshRSS 1.20+.

--- a/xExtension-ExtensionManager/metadata.json
+++ b/xExtension-ExtensionManager/metadata.json
@@ -2,7 +2,7 @@
     "name": "Extension Manager",
     "author": "featurecreep-cron",
     "description": "Install, update, and remove extensions from the settings page",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "entrypoint": "ExtensionManager",
     "type": "user"
 }

--- a/xExtension-ExtensionManager/static/script.js
+++ b/xExtension-ExtensionManager/static/script.js
@@ -538,7 +538,22 @@
         selfBadge.textContent = '(self)';
         tdAction.appendChild(selfBadge);
       } else if (info) {
-        if (isAdmin && compareVersions(String(ext.version), info.version) > 0) {
+        // Only one copy can be installed, so a section whose source is not the
+        // one the installed copy came from offers a switch rather than an
+        // update. Without this the action cell keys on version alone: with the
+        // same version on both branches it shows a bare "Installed" badge and
+        // there is no way back, and with the other branch ahead the comparison
+        // is against a version this section does not have. Origin unknown
+        // (installed before source markers, no sidecar) falls through to the
+        // version comparison \u2014 an install we cannot place is not evidence that
+        // it came from somewhere else.
+        var originKnown = !!(info.source || info.branch);
+        var fromOtherSource = originKnown &&
+          ((info.source || null) !== (ext.url || null) || (info.branch || null) !== (ext.branch || null));
+
+        if (isAdmin && fromOtherSource) {
+          tdAction.appendChild(makeInstallButton('Switch to ' + (ext.branch || 'this source'), null, ext.name, ext.dir, catalogToken));
+        } else if (isAdmin && compareVersions(String(ext.version), info.version) > 0) {
           tdAction.appendChild(makeInstallButton('Update', null, ext.name, ext.dir, catalogToken));
         } else {
           var badge = document.createElement('span');
@@ -559,13 +574,15 @@
   }
 
   function makeInstallButton(label, extUrl, extName, extDir, catalogToken) {
+    var isSwitch = label.indexOf('Switch') === 0;
+    var variant = label === 'Update' ? 'ext-mgr-update' : (isSwitch ? 'ext-mgr-switch' : 'ext-mgr-install');
     var btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'ext-mgr-btn ' + (label === 'Update' ? 'ext-mgr-update' : 'ext-mgr-install');
+    btn.className = 'ext-mgr-btn ' + variant;
     btn.textContent = label;
     btn.addEventListener('click', function () {
       btn.disabled = true;
-      btn.textContent = label === 'Install' ? 'Installing...' : 'Updating...';
+      btn.textContent = label === 'Install' ? 'Installing...' : (isSwitch ? 'Switching...' : 'Updating...');
 
       var params = {};
       if (extDir && catalogToken) {
@@ -586,7 +603,7 @@
           } else {
             btn.textContent = '\u2713 Done';
             btn.className = 'ext-mgr-btn ext-mgr-done';
-            showNotification(extName + ' ' + (label === 'Install' ? 'installed' : 'updated'));
+            showNotification(extName + ' ' + (label === 'Install' ? 'installed' : (isSwitch ? 'switched to ' + label.replace(/^Switch to /, '') : 'updated')));
             setTimeout(function () { window.location.reload(); }, 1500);
           }
         } else {

--- a/xExtension-ExtensionManager/static/style.css
+++ b/xExtension-ExtensionManager/static/style.css
@@ -14,6 +14,10 @@
 
 .ext-mgr-install { background: #4CAF50; color: #fff !important; border-color: #43A047; }
 .ext-mgr-update { background: #FF9800; color: #fff !important; border-color: #F57C00; }
+/* Switching sources replaces the installed copy with one from a different
+   branch, which may be a downgrade — distinct from the green install and the
+   orange update so it is not clicked by reflex. */
+.ext-mgr-switch { background: #5C6BC0; color: #fff !important; border-color: #3F51B5; }
 .ext-mgr-done { background: transparent; color: inherit !important; border-color: currentColor; cursor: default; opacity: 0.6; }
 .ext-mgr-queued { background: #1976D2; color: #fff !important; border-color: #1565C0; cursor: default; }
 


### PR DESCRIPTION
0.5.0 made branch sources installable but left them a **one-way door**.

The action cell keyed on version order alone. Installed from `develop` at 0.1.7 with `main` also at 0.1.7 → both sections render a bare "✓ Installed" badge and there is no way back. Worse when the other branch is ahead: the comparison runs against a version the section being viewed does not have, so it still shows a badge.

Reproduced on a live instance before changing anything — the `main` section listed Right-Click Actions as "Installed **0.1.7 develop**", available 0.1.7, action: a dead badge.

## Change

A section whose source is not the one the installed copy came from now offers **Switch to `<branch>`**, which reinstalls from that section and records the new origin in the sidecar.

- Offered on **difference of origin, not version order** — so returning to a branch that is *behind* the one you are on works, which is the normal case after testing something on `develop`.
- Coloured apart from Install (green) and Update (orange) because it can be a downgrade.
- An install with **no recorded origin** (predating source markers) falls through to the version comparison unchanged. An install we cannot place is not evidence it came from somewhere else, and treating it as such would put a Switch button in every section at once.

## Verification

The decision logic was exercised against the real catalog and installed-marker data from a FreshRSS 1.28.1 instance carrying Right-Click Actions 0.1.7 from `develop`:

| scenario | action |
|---|---|
| `main` section, same version | **Switch to main** |
| `develop` section (its own origin) | ✓ Installed |
| `main` behind develop | **Switch to main** |
| `main` ahead | **Switch to main** |
| legacy install, no marker, same version | ✓ Installed |
| legacy install, newer available | Update |

`node --check` clean. Version bumped 0.5.0 → 0.5.1.

**Testing note:** Extension Manager still cannot update *itself* from its own UI — its row renders `(self)` — so this build has to be put in place by file copy or the queued-install script, not by clicking Update.