### PR TITLE
feat(extmgr): update itself in two named steps

### DIFF
--- a/xExtension-ExtensionManager/Controllers/extmgrController.php
+++ b/xExtension-ExtensionManager/Controllers/extmgrController.php
@@ -18,6 +18,35 @@ final class FreshExtension_extmgr_Controller extends Minz_ActionController {
         }
     }
 
+    /**
+     * Arms the staged self-update. The swap itself is not done here: it
+     * happens at the start of the next GET, before controllers and views are
+     * loaded, because this request is already running out of the directory
+     * being replaced.
+     */
+    public function applyselfAction(): void {
+        $this->requireAdmin();
+        if (!Minz_Request::isPost()) {
+            $this->sendJson(['error' => 'POST required'], 405);
+        }
+        $result = ExtensionManagerExtension::requestSelfActivation();
+        if ($result === true) {
+            $this->sendJson(['success' => true, 'message' => 'Applying — reloading into the new version']);
+        }
+        $this->sendJson(['error' => is_string($result) ? $result : 'Unknown error'], 500);
+    }
+
+    public function discardselfAction(): void {
+        $this->requireAdmin();
+        if (!Minz_Request::isPost()) {
+            $this->sendJson(['error' => 'POST required'], 405);
+        }
+        if (ExtensionManagerExtension::discardSelfUpdate()) {
+            $this->sendJson(['success' => true, 'message' => 'Staged update discarded']);
+        }
+        $this->sendJson(['error' => 'Could not remove the staged copy'], 500);
+    }
+
     public function installAction(): void {
         $this->requireAdmin();
         if (!Minz_Request::isPost()) {
@@ -40,6 +69,36 @@ final class FreshExtension_extmgr_Controller extends Minz_ActionController {
             $entry = ExtensionManagerExtension::getCatalogEntry($catalogToken);
             $srcUrl = $entry['url'] ?? null;
             $srcBranch = $entry['branch'] ?? null;
+
+            // Updating ourselves cannot be a copy over the running tree, so it
+            // becomes a staged copy the user applies as a second step.
+            if (ExtensionManagerExtension::isSelfDir($dir)) {
+                if (!ExtensionManagerExtension::extensionsWritable()) {
+                    // No writable extensions directory means no rename either;
+                    // hand it to the queue, which install-queued.sh applies
+                    // out-of-band using the same swap.
+                    $result = ExtensionManagerExtension::queueInstall($tmpDir, $dir, $srcUrl, $srcBranch);
+                    if ($result === true) {
+                        $this->sendJson([
+                            'success' => true,
+                            'queued' => true,
+                            'message' => 'Extension Manager queued — run install-queued.sh to apply it',
+                        ]);
+                    }
+                    $this->sendJson(['error' => is_string($result) ? $result : 'Unknown error'], 500);
+                }
+                $result = ExtensionManagerExtension::stageSelfUpdate($tmpDir, $dir, $srcUrl, $srcBranch);
+                if ($result === true) {
+                    $pending = ExtensionManagerExtension::pendingSelfUpdate();
+                    $this->sendJson([
+                        'success' => true,
+                        'staged' => true,
+                        'version' => $pending['version'] ?? null,
+                        'message' => 'Extension Manager ' . ($pending['version'] ?? '') . ' downloaded and verified — apply it to finish',
+                    ]);
+                }
+                $this->sendJson(['error' => is_string($result) ? $result : 'Unknown error'], 500);
+            }
 
             if (ExtensionManagerExtension::extensionsWritable()) {
                 $result = ExtensionManagerExtension::installFromExtracted($tmpDir, $dir, $srcUrl, $srcBranch);

--- a/xExtension-ExtensionManager/README.md
+++ b/xExtension-ExtensionManager/README.md
@@ -74,6 +74,34 @@ The switch is offered on the difference in origin, not on version order — you 
 
 An extension installed before source tracking existed has no recorded origin. Those keep the old behaviour — Update when a newer version is available — since an install that cannot be placed is not evidence that it came from somewhere else.
 
+## Updating Extension Manager itself
+
+Extension Manager cannot copy a new version over the directory it is running from: FreshRSS boots every extension on every request, and a recursive copy has a visible half-written state that would fatal the whole site rather than just this page. So its own update is two steps, each named for what it does.
+
+**Download update** fetches the new version and builds it alongside the running one, then verifies it before it is allowed anywhere near activation:
+
+- the manifest parses and its `entrypoint` resolves to `ExtensionManagerExtension`
+- every `.php` file is parsed with `token_get_all(..., TOKEN_PARSE)` — a truncated download or a bad commit is caught here, not at the next request's `include`
+- `Controllers/`, `static/` and `views/` are present
+
+A staged copy holds its manifest as `metadata.json.pending`, so FreshRSS's extension scan cannot see it. Nothing about the running install has changed at this point, and a staged copy that is never applied is inert.
+
+**Apply update** swaps them at the start of the next request, before any controller or view is loaded, then reloads into the new version. The swap is renames only:
+
+```
+live    -> .extmgr-rollback-<timestamp>   (and its manifest renamed away)
+staged  -> live
+staged manifest -> metadata.json          (last: the new version becomes visible)
+```
+
+At no point do two directories carry a valid manifest, so the class is never declared twice. Every intermediate state is "Extension Manager is momentarily missing", which FreshRSS renders without complaint and the next request repairs. The previous version stays on disk as `.extmgr-rollback-<timestamp>` until the next update.
+
+Applying is deliberately separate from staging so that merely browsing never swaps the code out from under you.
+
+**What this cannot do:** if a staged copy is broken in a way the verifier does not catch, the code that would roll it back is the code that is broken. That is why verification happens before the swap and why the previous version is kept — recovery is one `mv`, not a reinstall.
+
+If the extensions directory is not writable, the update is queued instead and `install-queued.sh` performs the same swap out of band.
+
 ## Compatibility
 
 Requires FreshRSS 1.20+.

--- a/xExtension-ExtensionManager/README.md
+++ b/xExtension-ExtensionManager/README.md
@@ -96,7 +96,7 @@ staged manifest -> metadata.json          (last: the new version becomes visible
 
 At no point do two directories carry a valid manifest, so the class is never declared twice. Every intermediate state is "Extension Manager is momentarily missing", which FreshRSS renders without complaint and the next request repairs. The previous version stays on disk as `.extmgr-rollback-<timestamp>` until the next update.
 
-Applying is deliberately separate from staging so that merely browsing never swaps the code out from under you.
+Applying is deliberately separate from staging so that merely browsing never swaps the code out from under you. A staged copy you have changed your mind about is removed with **Discard**, which deletes it and leaves the running version untouched.
 
 **What this cannot do:** if a staged copy is broken in a way the verifier does not catch, the code that would roll it back is the code that is broken. That is why verification happens before the swap and why the previous version is kept — recovery is one `mv`, not a reinstall.
 

--- a/xExtension-ExtensionManager/README.md
+++ b/xExtension-ExtensionManager/README.md
@@ -66,6 +66,14 @@ Only one copy of a given extension can be installed at a time. When the installe
 
 A branch that does not exist is reported as an error. It is never silently replaced with the default branch, because that would install code you did not ask for and report success.
 
+### Switching branches
+
+In a section whose branch is not the one the installed copy came from, the action is **Switch to `<branch>`** instead of Install or Update. It replaces the installed copy with that section's build and records the new origin, so testing from `develop` and returning to `main` is a single click in each direction.
+
+The switch is offered on the difference in origin, not on version order — you can move back to a branch that is behind the one you are on, which is the usual case after testing something on `develop`. Because that can be a downgrade, the button is coloured differently from Install and Update.
+
+An extension installed before source tracking existed has no recorded origin. Those keep the old behaviour — Update when a newer version is available — since an install that cannot be placed is not evidence that it came from somewhere else.
+
 ## Compatibility
 
 Requires FreshRSS 1.20+.

--- a/xExtension-ExtensionManager/extension.php
+++ b/xExtension-ExtensionManager/extension.php
@@ -24,7 +24,325 @@ class ExtensionManagerExtension extends Minz_Extension {
         return is_writable(dirname(dirname(__FILE__)));
     }
 
+    /* ===================== Self-update =====================
+     *
+     * Minz finds extensions by scanning every directory under the extensions
+     * path and loading any that carry a valid metadata.json — the directory
+     * name is not part of the test (lib/Minz/ExtensionManager.php). So two
+     * directories holding this extension's metadata means extension.php is
+     * included twice, ExtensionManagerExtension is declared twice, and the
+     * fatal takes down all of FreshRSS rather than just this page. The same
+     * scan is why the old in-place install refused to touch this extension:
+     * a recursive copy has an observable half-written state, and every request
+     * boots through this file.
+     *
+     * Everything below is arranged so neither can happen. A staged tree keeps
+     * its manifest as metadata.json.pending and so is invisible to discovery;
+     * the version being replaced has its manifest renamed away before the new
+     * one is put in place. Activation is renames only — never a copy — and the
+     * failure modes are all "Extension Manager is briefly missing", which
+     * FreshRSS survives, and which the next request repairs.
+     */
+    private const SELF_DIR = 'xExtension-ExtensionManager';
+    private const STAGE_DIR = '.extmgr-staged';
+    private const ROLLBACK_PREFIX = '.extmgr-rollback-';
+    private const PENDING_MANIFEST = 'metadata.json.pending';
+    private const DISABLED_MANIFEST = 'metadata.json.disabled';
+    private const PENDING_RECORD = '.pending.json';
+
+    private static function extensionsPath(): string {
+        return dirname(dirname(__FILE__));
+    }
+
+    /** The directory this file is running from, rather than a composed name, so a renamed install still works. */
+    private static function selfPath(): string {
+        return dirname(__FILE__);
+    }
+
+    private static function stagePath(): string {
+        return self::extensionsPath() . '/' . self::STAGE_DIR;
+    }
+
+    public static function isSelfDir(string $extDirName): bool {
+        return basename($extDirName) === self::SELF_DIR;
+    }
+
+    /**
+     * Everything that must hold before a staged tree is allowed to replace the
+     * running one. A bad payload here is not a failed update, it is a FreshRSS
+     * that will not boot, so this refuses on anything it cannot confirm.
+     */
+    public static function verifyStagedTree(string $dir): ?string {
+        $manifestPath = $dir . '/' . self::PENDING_MANIFEST;
+        if (!is_file($manifestPath)) {
+            return 'staged copy has no manifest';
+        }
+        $meta = json_decode((string) file_get_contents($manifestPath), true);
+        if (!is_array($meta)) {
+            return 'staged manifest is not valid JSON';
+        }
+        foreach (['name', 'entrypoint', 'version'] as $key) {
+            if (!isset($meta[$key]) || !is_string($meta[$key]) || $meta[$key] === '') {
+                return 'staged manifest is missing "' . $key . '"';
+            }
+        }
+        if ($meta['entrypoint'] !== 'ExtensionManager') {
+            return 'staged manifest entrypoint is "' . $meta['entrypoint'] . '", expected ExtensionManager';
+        }
+        if (!is_file($dir . '/extension.php')) {
+            return 'staged copy has no extension.php';
+        }
+        // Minz derives the class name from the entrypoint and warns if it is
+        // absent; absent here means the swap produces an extension that loads
+        // and then does nothing.
+        if (strpos((string) file_get_contents($dir . '/extension.php'), 'class ExtensionManagerExtension') === false) {
+            return 'staged extension.php does not declare ExtensionManagerExtension';
+        }
+        foreach (['Controllers', 'static', 'views'] as $sub) {
+            if (!is_dir($dir . '/' . $sub)) {
+                return 'staged copy is missing ' . $sub . '/';
+            }
+        }
+        return self::firstSyntaxError($dir);
+    }
+
+    /**
+     * Parse every PHP file without running any of it. token_get_all() with
+     * TOKEN_PARSE raises ParseError on invalid syntax, which is the check that
+     * makes self-update defensible: a truncated download or a bad commit is
+     * caught here rather than at the next request's include.
+     */
+    private static function firstSyntaxError(string $dir): ?string {
+        $walker = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($walker as $file) {
+            if (!$file->isFile() || strtolower($file->getExtension()) !== 'php') {
+                continue;
+            }
+            $src = file_get_contents($file->getPathname());
+            if ($src === false) {
+                return 'cannot read ' . $file->getFilename();
+            }
+            try {
+                token_get_all($src, TOKEN_PARSE);
+            } catch (ParseError $e) {
+                return 'syntax error in ' . $file->getFilename() . ' — ' . $e->getMessage();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Step 1. Build the new version alongside the running one and verify it.
+     * Nothing about the live install changes here, and a staged tree that is
+     * never applied is inert.
+     */
+    public static function stageSelfUpdate(string $tmpDir, string $extDirName, ?string $url = null, ?string $branch = null): string|bool {
+        if (!self::extensionsWritable()) {
+            return 'Extensions directory is not writable — use the queued install script.';
+        }
+        $sourceDir = self::findSourceInExtracted($tmpDir, $extDirName);
+        if ($sourceDir === null) {
+            return 'Extension Manager not found in the downloaded archive';
+        }
+        if (!is_file($sourceDir . '/metadata.json')) {
+            return 'Downloaded copy has no metadata.json';
+        }
+
+        // Assemble under a scratch name and publish with a single rename, so a
+        // directory named .extmgr-staged never exists half-copied.
+        $scratch = self::stagePath() . '.incoming';
+        self::recursiveDelete($scratch);
+        self::recursiveDelete(self::stagePath());
+        self::recursiveCopy($sourceDir, $scratch);
+
+        // Withhold the manifest before anything else: from this point the tree
+        // is on disk but cannot be discovered as a second copy of us.
+        if (!@rename($scratch . '/metadata.json', $scratch . '/' . self::PENDING_MANIFEST)) {
+            self::recursiveDelete($scratch);
+            return 'Could not withhold the staged manifest';
+        }
+        self::writeSourceMarker($scratch, $url, $branch);
+
+        $error = self::verifyStagedTree($scratch);
+        if ($error !== null) {
+            self::recursiveDelete($scratch);
+            return 'Refused to stage: ' . $error;
+        }
+
+        $meta = json_decode((string) file_get_contents($scratch . '/' . self::PENDING_MANIFEST), true);
+        @file_put_contents($scratch . '/' . self::PENDING_RECORD, json_encode([
+            'version' => is_array($meta) ? ($meta['version'] ?? '?') : '?',
+            'source' => $url,
+            'branch' => $branch,
+            'staged_at' => date('c'),
+            'apply' => false,
+        ]));
+
+        if (!@rename($scratch, self::stagePath())) {
+            self::recursiveDelete($scratch);
+            return 'Could not publish the staged copy';
+        }
+        self::pruneRollbacks();
+        return true;
+    }
+
+    public static function pendingSelfUpdate(): ?array {
+        $record = self::stagePath() . '/' . self::PENDING_RECORD;
+        if (!is_file($record)) {
+            return null;
+        }
+        $data = json_decode((string) file_get_contents($record), true);
+        return is_array($data) ? $data : null;
+    }
+
+    public static function discardSelfUpdate(): bool {
+        self::recursiveDelete(self::stagePath());
+        return !is_dir(self::stagePath());
+    }
+
+    /**
+     * Step 2a. Arm the staged copy. Kept separate from activation so that
+     * merely navigating never swaps the code out from under you — a staged
+     * update sits untouched until it is asked for.
+     */
+    public static function requestSelfActivation(): string|bool {
+        $pending = self::pendingSelfUpdate();
+        if ($pending === null) {
+            return 'Nothing is staged';
+        }
+        $error = self::verifyStagedTree(self::stagePath());
+        if ($error !== null) {
+            self::discardSelfUpdate();
+            return 'Staged copy failed verification and was discarded: ' . $error;
+        }
+        $pending['apply'] = true;
+        if (@file_put_contents(self::stagePath() . '/' . self::PENDING_RECORD, json_encode($pending)) === false) {
+            return 'Could not arm the staged copy';
+        }
+        return true;
+    }
+
+    /** Rollback copies are inert (their manifest is renamed away); keep the most recent one only. */
+    private static function pruneRollbacks(int $keep = 1): void {
+        $entries = @scandir(self::extensionsPath()) ?: [];
+        $rollbacks = array_values(array_filter($entries, fn($e) => strpos($e, self::ROLLBACK_PREFIX) === 0));
+        sort($rollbacks);
+        foreach (array_slice($rollbacks, 0, max(0, count($rollbacks) - $keep)) as $old) {
+            self::recursiveDelete(self::extensionsPath() . '/' . $old);
+        }
+    }
+
+    /**
+     * Step 2b. Runs at the top of every boot, but the common case is one
+     * is_dir() and out.
+     *
+     * Only on GET: a swap during the POST that requested it would leave that
+     * request's controller and views coming from the new tree while this
+     * process holds the old class in memory.
+     */
+    private static function maybeActivateSelfUpdate(): void {
+        if (!is_dir(self::stagePath())) {
+            return;
+        }
+        // Never from the CLI: actualize and the update scripts boot extensions
+        // too, and a swap there would exit() in the middle of a feed refresh
+        // with nobody to see the redirect.
+        if (PHP_SAPI === 'cli' || !isset($_SERVER['REQUEST_METHOD']) || $_SERVER['REQUEST_METHOD'] !== 'GET') {
+            return;
+        }
+        $pending = self::pendingSelfUpdate();
+        if ($pending === null || empty($pending['apply'])) {
+            return;
+        }
+
+        $error = self::activateSelfUpdate();
+        if ($error !== null) {
+            Minz_Log::error('ExtensionManager self-update: ' . $error);
+            return;
+        }
+
+        // Reload before anything else loads. extension.php is already included
+        // for this request, but controllers and views are pulled in lazily and
+        // would now come from the new tree — old class, new views. A fresh
+        // request has no such split.
+        if (!headers_sent()) {
+            $uri = (string) ($_SERVER['REQUEST_URI'] ?? './');
+            header('Location: ' . str_replace(["\r", "\n"], '', $uri));
+            exit();
+        }
+    }
+
+    /**
+     * Renames only. The ordering is the safety argument, so read it before
+     * changing it: at no instant may two directories under the extensions path
+     * carry a valid metadata.json, because that is a double include of this
+     * file and a fatal for the whole site.
+     *
+     *   1. live -> rollback         live is gone; only one manifest exists
+     *   2. rollback manifest away   rollback can no longer be discovered
+     *   3. staged -> live           still no manifest at the live path
+     *   4. staged manifest in place  new version becomes discoverable
+     *
+     * Every window between those steps is "Extension Manager is missing",
+     * which FreshRSS renders happily and the next request repairs.
+     */
+    private static function activateSelfUpdate(): ?string {
+        $lockPath = self::extensionsPath() . '/.extmgr.lock';
+        $lock = @fopen($lockPath, 'c');
+        if ($lock === false) {
+            return 'could not open the activation lock';
+        }
+        if (!flock($lock, LOCK_EX | LOCK_NB)) {
+            fclose($lock);
+            return null; // another request is mid-swap; nothing to report
+        }
+
+        try {
+            $stage = self::stagePath();
+            $live = self::selfPath();
+
+            $error = self::verifyStagedTree($stage);
+            if ($error !== null) {
+                self::recursiveDelete($stage);
+                return 'staged copy failed verification and was discarded: ' . $error;
+            }
+
+            $rollback = self::extensionsPath() . '/' . self::ROLLBACK_PREFIX . date('YmdHis');
+            if (!@rename($live, $rollback)) {
+                return 'could not move the running version aside';
+            }
+            @rename($rollback . '/metadata.json', $rollback . '/' . self::DISABLED_MANIFEST);
+
+            if (!@rename($stage, $live)) {
+                // Put it back exactly as it was, manifest last.
+                @rename($rollback . '/' . self::DISABLED_MANIFEST, $rollback . '/metadata.json');
+                @rename($rollback, $live);
+                return 'could not move the staged copy into place; the running version was restored';
+            }
+
+            if (!@rename($live . '/' . self::PENDING_MANIFEST, $live . '/metadata.json')) {
+                return 'staged copy is in place but its manifest could not be enabled';
+            }
+
+            @unlink($live . '/' . self::PENDING_RECORD);
+
+            // With opcache.validate_timestamps=0 the swapped files would keep
+            // running as the old bytecode until PHP restarts.
+            if (function_exists('opcache_reset')) {
+                @opcache_reset();
+            }
+            return null;
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+            @unlink($lockPath);
+        }
+    }
+
     public function init() {
+        self::maybeActivateSelfUpdate();
         $this->registerController('extmgr');
         $this->registerViews();
 
@@ -45,6 +363,7 @@ class ExtensionManagerExtension extends Minz_Extension {
             'is_admin' => FreshRSS_Auth::hasAccess('admin'),
             'writable' => self::extensionsWritable(),
             'queued' => self::getQueuedInstalls(),
+            'pendingSelf' => self::pendingSelfUpdate(),
         ];
         return $vars;
     }
@@ -203,9 +522,10 @@ class ExtensionManagerExtension extends Minz_Extension {
     public static function queueInstall(string $tmpDir, string $extDirName, ?string $url = null, ?string $branch = null): string|bool {
         $extDirName = basename($extDirName);
 
-        if ($extDirName === 'xExtension-ExtensionManager') {
-            return 'Extension Manager cannot update itself this way. Replace the files manually.';
-        }
+        // Self is allowed through here: the queue is applied by
+        // install-queued.sh outside any request, and that script replaces this
+        // extension with the same rename sequence used in-app rather than by
+        // copying over the running tree.
 
         // Find source in extracted dir
         $sourceDir = self::findSourceInExtracted($tmpDir, $extDirName);
@@ -543,8 +863,12 @@ class ExtensionManagerExtension extends Minz_Extension {
             return 'Extracted repo not found. Try refreshing the catalog.';
         }
 
+        // Stays blocked, and must. This path copies file by file over the live
+        // directory, which is the one serving the request — a concurrent boot
+        // can read a half-written extension.php and fatal the whole site.
+        // Self-update goes through stageSelfUpdate() + activateSelfUpdate().
         if ($extDirName === 'xExtension-ExtensionManager') {
-            return 'Extension Manager cannot update itself this way. Replace the files manually.';
+            return 'Extension Manager updates itself by staging, not by copying over the running copy — use Download update.';
         }
 
         // Validate tmpDir is within expected temp directory

--- a/xExtension-ExtensionManager/install-queued.sh
+++ b/xExtension-ExtensionManager/install-queued.sh
@@ -52,12 +52,48 @@ if [ -d "$QUEUE_DIR" ]; then
             continue
         fi
 
+        target="$EXT_PATH/$dir_name"
+
+        # Extension Manager is replaced by renames rather than by copying over
+        # the live tree. FreshRSS loads any directory under $EXT_PATH that has a
+        # valid metadata.json, so two copies carrying one would declare the same
+        # class twice and take the whole site down. Withholding the manifest
+        # keeps a half-built tree invisible, and the ordering below means the
+        # worst intermediate state is "Extension Manager is missing".
         if [ "$dir_name" = "xExtension-ExtensionManager" ]; then
-            echo "[ExtMgr] Skipping $dir_name — cannot self-update via queue"
+            echo "[ExtMgr] Updating $dir_name (staged swap)"
+            staged="$EXT_PATH/.extmgr-staged-queue"
+            rollback="$EXT_PATH/.extmgr-rollback-$(date +%Y%m%d%H%M%S)"
+
+            rm -rf "$staged"
+            cp -r "$ext_dir" "$staged"
+
+            if ! php -l "$staged/extension.php" >/dev/null 2>&1; then
+                echo "[ExtMgr] $dir_name — FAILED, staged extension.php does not parse; left the running copy alone"
+                rm -rf "$staged"
+                continue
+            fi
+
+            mv "$staged/metadata.json" "$staged/metadata.json.pending"
+
+            if [ -d "$target" ]; then
+                mv "$target" "$rollback"
+                mv "$rollback/metadata.json" "$rollback/metadata.json.disabled" 2>/dev/null || true
+            fi
+
+            if mv "$staged" "$target"; then
+                mv "$target/metadata.json.pending" "$target/metadata.json"
+                echo "[ExtMgr] $dir_name — done (previous version kept at $rollback)"
+            else
+                echo "[ExtMgr] $dir_name — FAILED, restoring previous version"
+                rm -rf "$staged"
+                if [ -d "$rollback" ]; then
+                    mv "$rollback/metadata.json.disabled" "$rollback/metadata.json" 2>/dev/null || true
+                    mv "$rollback" "$target"
+                fi
+            fi
             continue
         fi
-
-        target="$EXT_PATH/$dir_name"
 
         if [ -d "$target" ]; then
             echo "[ExtMgr] Updating $dir_name"

--- a/xExtension-ExtensionManager/metadata.json
+++ b/xExtension-ExtensionManager/metadata.json
@@ -2,7 +2,7 @@
     "name": "Extension Manager",
     "author": "featurecreep-cron",
     "description": "Install, update, and remove extensions from the settings page",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "entrypoint": "ExtensionManager",
     "type": "user"
 }

--- a/xExtension-ExtensionManager/metadata.json
+++ b/xExtension-ExtensionManager/metadata.json
@@ -2,7 +2,7 @@
     "name": "Extension Manager",
     "author": "featurecreep-cron",
     "description": "Install, update, and remove extensions from the settings page",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "entrypoint": "ExtensionManager",
     "type": "user"
 }

--- a/xExtension-ExtensionManager/metadata.json
+++ b/xExtension-ExtensionManager/metadata.json
@@ -2,7 +2,7 @@
     "name": "Extension Manager",
     "author": "featurecreep-cron",
     "description": "Install, update, and remove extensions from the settings page",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "entrypoint": "ExtensionManager",
     "type": "user"
 }

--- a/xExtension-ExtensionManager/static/script.js
+++ b/xExtension-ExtensionManager/static/script.js
@@ -584,8 +584,13 @@
       wrap.appendChild(makeApplyButton(pendingSelf.version));
       var note = document.createElement('span');
       note.className = 'ext-mgr-staged-note';
-      note.textContent = pendingSelf.version ? pendingSelf.version + ' verified' : 'verified';
+      note.textContent = (pendingSelf.version || 'staged') +
+        (pendingSelf.branch ? ' from ' + pendingSelf.branch : '') + ' verified';
       wrap.appendChild(note);
+      // Staging is reversible and should look it — without this the only way
+      // out of a staged copy you have changed your mind about is deleting the
+      // directory by hand.
+      wrap.appendChild(makeDiscardButton());
       return wrap;
     }
 
@@ -622,6 +627,29 @@
       }).catch(function (err) {
         btn.disabled = false;
         btn.textContent = 'Apply update';
+        showNotification('Error: ' + err.message, true);
+      });
+    });
+    return btn;
+  }
+
+  function makeDiscardButton() {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'ext-mgr-discard';
+    btn.textContent = 'Discard';
+    btn.title = 'Delete the staged copy; the running version is not touched';
+    btn.addEventListener('click', function () {
+      btn.disabled = true;
+      apiCall('discardself', {}).then(function (data) {
+        if (data.success) {
+          window.location.reload();
+        } else {
+          btn.disabled = false;
+          showNotification(data.error || 'Could not discard the staged copy', true);
+        }
+      }).catch(function (err) {
+        btn.disabled = false;
         showNotification('Error: ' + err.message, true);
       });
     });

--- a/xExtension-ExtensionManager/static/script.js
+++ b/xExtension-ExtensionManager/static/script.js
@@ -538,7 +538,22 @@
         selfBadge.textContent = '(self)';
         tdAction.appendChild(selfBadge);
       } else if (info) {
-        if (isAdmin && compareVersions(String(ext.version), info.version) > 0) {
+        // Only one copy can be installed, so a section whose source is not the
+        // one the installed copy came from offers a switch rather than an
+        // update. Without this the action cell keys on version alone: with the
+        // same version on both branches it shows a bare "Installed" badge and
+        // there is no way back, and with the other branch ahead the comparison
+        // is against a version this section does not have. Origin unknown
+        // (installed before source markers, no sidecar) falls through to the
+        // version comparison \u2014 an install we cannot place is not evidence that
+        // it came from somewhere else.
+        var originKnown = !!(info.source || info.branch);
+        var fromOtherSource = originKnown &&
+          ((info.source || null) !== (ext.url || null) || (info.branch || null) !== (ext.branch || null));
+
+        if (isAdmin && fromOtherSource) {
+          tdAction.appendChild(makeInstallButton('Switch to ' + (ext.branch || 'this source'), null, ext.name, ext.dir, catalogToken));
+        } else if (isAdmin && compareVersions(String(ext.version), info.version) > 0) {
           tdAction.appendChild(makeInstallButton('Update', null, ext.name, ext.dir, catalogToken));
         } else {
           var badge = document.createElement('span');
@@ -559,13 +574,15 @@
   }
 
   function makeInstallButton(label, extUrl, extName, extDir, catalogToken) {
+    var isSwitch = label.indexOf('Switch') === 0;
+    var variant = label === 'Update' ? 'ext-mgr-update' : (isSwitch ? 'ext-mgr-switch' : 'ext-mgr-install');
     var btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'ext-mgr-btn ' + (label === 'Update' ? 'ext-mgr-update' : 'ext-mgr-install');
+    btn.className = 'ext-mgr-btn ' + variant;
     btn.textContent = label;
     btn.addEventListener('click', function () {
       btn.disabled = true;
-      btn.textContent = label === 'Install' ? 'Installing...' : 'Updating...';
+      btn.textContent = label === 'Install' ? 'Installing...' : (isSwitch ? 'Switching...' : 'Updating...');
 
       var params = {};
       if (extDir && catalogToken) {
@@ -586,7 +603,7 @@
           } else {
             btn.textContent = '\u2713 Done';
             btn.className = 'ext-mgr-btn ext-mgr-done';
-            showNotification(extName + ' ' + (label === 'Install' ? 'installed' : 'updated'));
+            showNotification(extName + ' ' + (label === 'Install' ? 'installed' : (isSwitch ? 'switched to ' + label.replace(/^Switch to /, '') : 'updated')));
             setTimeout(function () { window.location.reload(); }, 1500);
           }
         } else {

--- a/xExtension-ExtensionManager/static/script.js
+++ b/xExtension-ExtensionManager/static/script.js
@@ -6,6 +6,7 @@
   var isAdmin = false;
   var isWritable = false;
   var queued = {};
+  var pendingSelf = null;
 
   var _initRetries = 0;
   function init() {
@@ -22,6 +23,7 @@
     isAdmin = !!extConfig.configuration.is_admin;
     isWritable = !!extConfig.configuration.writable;
     queued = extConfig.configuration.queued || {};
+    pendingSelf = extConfig.configuration.pendingSelf || null;
 
     if (!isExtensionsPage()) return;
 
@@ -533,10 +535,7 @@
       var tdAction = document.createElement('td');
 
       if (ext.dir === 'xExtension-ExtensionManager') {
-        var selfBadge = document.createElement('span');
-        selfBadge.className = 'ext-mgr-installed-badge';
-        selfBadge.textContent = '(self)';
-        tdAction.appendChild(selfBadge);
+        tdAction.appendChild(selfAction(ext, info, catalogToken));
       } else if (info) {
         // Only one copy can be installed, so a section whose source is not the
         // one the installed copy came from offers a switch rather than an
@@ -573,6 +572,62 @@
     return table;
   }
 
+  // Extension Manager cannot copy over itself while it is the code serving the
+  // request, so its update is two named steps: Download update fetches and
+  // verifies a copy alongside the running one, Apply update swaps them at the
+  // start of the next request. Each button says what it does; neither of them
+  // is a reload, even though applying ends in one.
+  function selfAction(ext, info, catalogToken) {
+    if (pendingSelf) {
+      var wrap = document.createElement('span');
+      wrap.className = 'ext-mgr-self-pending';
+      wrap.appendChild(makeApplyButton(pendingSelf.version));
+      var note = document.createElement('span');
+      note.className = 'ext-mgr-staged-note';
+      note.textContent = pendingSelf.version ? pendingSelf.version + ' verified' : 'verified';
+      wrap.appendChild(note);
+      return wrap;
+    }
+
+    var newer = info && compareVersions(String(ext.version), info.version) > 0;
+    if (isAdmin && isWritable && newer) {
+      return makeInstallButton('Download update', null, ext.name, ext.dir, catalogToken);
+    }
+
+    var badge = document.createElement('span');
+    badge.className = 'ext-mgr-installed-badge';
+    // Without a writable extensions directory the swap cannot happen at all,
+    // and saying "(self)" would hide the reason.
+    badge.textContent = newer && !isWritable ? 'update available — run install-queued.sh' : '(self)';
+    return badge;
+  }
+
+  function makeApplyButton(version) {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'ext-mgr-btn ext-mgr-switch';
+    btn.textContent = 'Apply update';
+    btn.title = version ? 'Replace the running Extension Manager with the verified ' + version + ' copy' : '';
+    btn.addEventListener('click', function () {
+      btn.disabled = true;
+      btn.textContent = 'Applying...';
+      apiCall('applyself', {}).then(function (data) {
+        if (data.success) {
+          window.location.reload();
+        } else {
+          btn.disabled = false;
+          btn.textContent = 'Apply update';
+          showNotification(data.error || 'Could not apply the update', true);
+        }
+      }).catch(function (err) {
+        btn.disabled = false;
+        btn.textContent = 'Apply update';
+        showNotification('Error: ' + err.message, true);
+      });
+    });
+    return btn;
+  }
+
   function makeInstallButton(label, extUrl, extName, extDir, catalogToken) {
     var isSwitch = label.indexOf('Switch') === 0;
     var variant = label === 'Update' ? 'ext-mgr-update' : (isSwitch ? 'ext-mgr-switch' : 'ext-mgr-install');
@@ -600,6 +655,13 @@
             // Update queued state and show banner if not already visible
             queued[extDir || extName] = { name: extName, action: 'install' };
             refreshQueuedBanner();
+          } else if (data.staged) {
+            // Downloaded and verified, nothing replaced yet \u2014 the reload brings
+            // back the row with an Apply update button.
+            btn.textContent = 'Downloaded';
+            btn.className = 'ext-mgr-btn ext-mgr-done';
+            showNotification(data.message || (extName + ' downloaded and verified \u2014 apply it to finish'));
+            setTimeout(function () { window.location.reload(); }, 1200);
           } else {
             btn.textContent = '\u2713 Done';
             btn.className = 'ext-mgr-btn ext-mgr-done';

--- a/xExtension-ExtensionManager/static/style.css
+++ b/xExtension-ExtensionManager/static/style.css
@@ -18,6 +18,10 @@
    branch, which may be a downgrade — distinct from the green install and the
    orange update so it is not clicked by reflex. */
 .ext-mgr-switch { background: #5C6BC0; color: #fff !important; border-color: #3F51B5; }
+
+/* A staged self-update: downloaded and verified, not yet in place. */
+.ext-mgr-self-pending { display: inline-flex; align-items: center; gap: 0.5em; }
+.ext-mgr-staged-note { font-size: 0.8em; opacity: 0.7; }
 .ext-mgr-done { background: transparent; color: inherit !important; border-color: currentColor; cursor: default; opacity: 0.6; }
 .ext-mgr-queued { background: #1976D2; color: #fff !important; border-color: #1565C0; cursor: default; }
 

--- a/xExtension-ExtensionManager/static/style.css
+++ b/xExtension-ExtensionManager/static/style.css
@@ -22,6 +22,18 @@
 /* A staged self-update: downloaded and verified, not yet in place. */
 .ext-mgr-self-pending { display: inline-flex; align-items: center; gap: 0.5em; }
 .ext-mgr-staged-note { font-size: 0.8em; opacity: 0.7; }
+.ext-mgr-discard {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.8em;
+    opacity: 0.7;
+    text-decoration: underline;
+    cursor: pointer;
+    color: inherit;
+}
+.ext-mgr-discard:hover { opacity: 1; }
+.ext-mgr-discard:disabled { cursor: wait; opacity: 0.4; }
 .ext-mgr-done { background: transparent; color: inherit !important; border-color: currentColor; cursor: default; opacity: 0.6; }
 .ext-mgr-queued { background: #1976D2; color: #fff !important; border-color: #1565C0; cursor: default; }
 

--- a/xExtension-ExtensionManager/static/style.css
+++ b/xExtension-ExtensionManager/static/style.css
@@ -14,6 +14,10 @@
 
 .ext-mgr-install { background: #4CAF50; color: #fff !important; border-color: #43A047; }
 .ext-mgr-update { background: #FF9800; color: #fff !important; border-color: #F57C00; }
+/* Switching sources replaces the installed copy with one from a different
+   branch, which may be a downgrade — distinct from the green install and the
+   orange update so it is not clicked by reflex. */
+.ext-mgr-switch { background: #5C6BC0; color: #fff !important; border-color: #3F51B5; }
 .ext-mgr-done { background: transparent; color: inherit !important; border-color: currentColor; cursor: default; opacity: 0.6; }
 .ext-mgr-queued { background: #1976D2; color: #fff !important; border-color: #1565C0; cursor: default; }
 


### PR DESCRIPTION
Extension Manager was the one extension that always had to be replaced by hand — both install paths refused it with "Replace the files manually", and its row rendered a bare `(self)`.

## The refusal was correct

Two facts from `lib/Minz/ExtensionManager.php` (checked against the 1.28.1 tag, not just edge):

1. **Discovery scans every directory** under the extensions path and loads any carrying a valid `metadata.json` — the directory name is not part of the test. A second directory with our metadata means `extension.php` is included twice and `ExtensionManagerExtension` is declared twice: a fatal for the whole site, not just this page.
2. **`installFromExtracted()` copies file by file over the live directory**, which is the directory serving the request. A concurrent boot can read a half-written `extension.php`.

That path stays blocked, and now says why instead of just refusing.

## Download update

Builds the new version alongside the running one and verifies before it can go anywhere:

- manifest parses, `entrypoint` resolves to `ExtensionManagerExtension`
- **every `.php` parsed with `token_get_all(..., TOKEN_PARSE)`** — no execution, no shell; a truncated download or bad commit is caught here rather than at the next request's `include`
- `Controllers/`, `static/`, `views/` present

The staged tree carries its manifest as `metadata.json.pending`, so the extension scan cannot see it. Nothing about the running install changes, and a staged copy that is never applied is inert.

## Apply update

Swaps at the start of the next GET — before any controller or view loads — then reloads into the new version. Renames only:

```
live   -> .extmgr-rollback-<ts>   (manifest renamed away)
staged -> live
staged manifest -> metadata.json  (last)
```

**At no instant do two directories carry a valid manifest**, so the class is never declared twice. Every window between steps is "Extension Manager is momentarily missing", which FreshRSS renders happily and the next request repairs. Non-blocking `flock` so two requests cannot race; skipped on CLI so a feed refresh never swaps and `exit()`s mid-run; `opcache_reset()` after, or the new files run as old bytecode where `validate_timestamps=0`.

Applying is deliberately separate from staging: browsing never swaps code out from under you.

## Queue path

Opened to self as well — `install-queued.sh` performs the same rename sequence out of band and `php -l`s the staged `extension.php` before touching the live copy.

## Known limit

If a staged copy is broken in a way the verifier misses, the code that would roll it back is the code that is broken. Hence verification *before* the swap, and the previous version left on disk as `.extmgr-rollback-<ts>` so recovery is one `mv`, not a reinstall. Documented in the README rather than papered over.

## Verification status

`node --check` and `sh -n` clean; PHP is linted by CI here (no local PHP). **The swap itself has not been executed** — it needs a live instance. Testing should include the failure paths deliberately: stage a copy with a syntax error and confirm it refuses rather than swaps.

Version bumped 0.5.1 → 0.6.0.