### PR TITLE
fix(extmgr): let Extension Manager switch branches too

### DIFF
--- a/xExtension-ExtensionManager/README.md
+++ b/xExtension-ExtensionManager/README.md
@@ -98,6 +98,8 @@ At no point do two directories carry a valid manifest, so the class is never dec
 
 Applying is deliberately separate from staging so that merely browsing never swaps the code out from under you. A staged copy you have changed your mind about is removed with **Discard**, which deletes it and leaves the running version untouched.
 
+Extension Manager moves between branches the same way every other extension does, through the same two steps: in a section whose branch is not the one the running copy came from the button reads **Download from `<branch>`**, and applying it reads **Apply switch** rather than Apply update, because a move between branches is often a downgrade.
+
 **What this cannot do:** if a staged copy is broken in a way the verifier does not catch, the code that would roll it back is the code that is broken. That is why verification happens before the swap and why the previous version is kept — recovery is one `mv`, not a reinstall.
 
 If the extensions directory is not writable, the update is queued instead and `install-queued.sh` performs the same swap out of band.

--- a/xExtension-ExtensionManager/metadata.json
+++ b/xExtension-ExtensionManager/metadata.json
@@ -2,7 +2,7 @@
     "name": "Extension Manager",
     "author": "featurecreep-cron",
     "description": "Install, update, and remove extensions from the settings page",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "entrypoint": "ExtensionManager",
     "type": "user"
 }

--- a/xExtension-ExtensionManager/static/script.js
+++ b/xExtension-ExtensionManager/static/script.js
@@ -581,7 +581,12 @@
     if (pendingSelf) {
       var wrap = document.createElement('span');
       wrap.className = 'ext-mgr-self-pending';
-      wrap.appendChild(makeApplyButton(pendingSelf.version));
+      // Applying a copy from a different branch is a move, not an upgrade, and
+      // may well be a downgrade — the button should not call it an update.
+      var stagedIsSwitch = !!(info && (info.branch || info.source) &&
+        ((pendingSelf.branch || null) !== (info.branch || null) ||
+         (pendingSelf.source || null) !== (info.source || null)));
+      wrap.appendChild(makeApplyButton(pendingSelf.version, stagedIsSwitch));
       var note = document.createElement('span');
       note.className = 'ext-mgr-staged-note';
       note.textContent = (pendingSelf.version || 'staged') +
@@ -595,23 +600,36 @@
     }
 
     var newer = info && compareVersions(String(ext.version), info.version) > 0;
-    if (isAdmin && isWritable && newer) {
-      return makeInstallButton('Download update', null, ext.name, ext.dir, catalogToken);
+    // Same test the other rows use: an installed copy whose origin is not this
+    // section's source can be moved here whatever the version order says. This
+    // row used to check the version alone, which left Extension Manager with
+    // exactly the one-way door that branch switching was added to remove —
+    // installed from develop, viewing main at the same version, no way back.
+    var originKnown = !!(info && (info.source || info.branch));
+    var fromOtherSource = originKnown &&
+      ((info.source || null) !== (ext.url || null) || (info.branch || null) !== (ext.branch || null));
+
+    if (isAdmin && isWritable && (newer || fromOtherSource)) {
+      var label = fromOtherSource ? 'Download from ' + (ext.branch || 'this source') : 'Download update';
+      return makeInstallButton(label, null, ext.name, ext.dir, catalogToken);
     }
 
     var badge = document.createElement('span');
     badge.className = 'ext-mgr-installed-badge';
     // Without a writable extensions directory the swap cannot happen at all,
     // and saying "(self)" would hide the reason.
-    badge.textContent = newer && !isWritable ? 'update available — run install-queued.sh' : '(self)';
+    badge.textContent = (newer || fromOtherSource) && !isWritable
+      ? 'available — run install-queued.sh'
+      : '(self)';
     return badge;
   }
 
-  function makeApplyButton(version) {
+  function makeApplyButton(version, isSwitch) {
+    var label = isSwitch ? 'Apply switch' : 'Apply update';
     var btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'ext-mgr-btn ext-mgr-switch';
-    btn.textContent = 'Apply update';
+    btn.textContent = label;
     btn.title = version ? 'Replace the running Extension Manager with the verified ' + version + ' copy' : '';
     btn.addEventListener('click', function () {
       btn.disabled = true;
@@ -621,12 +639,12 @@
           window.location.reload();
         } else {
           btn.disabled = false;
-          btn.textContent = 'Apply update';
+          btn.textContent = label;
           showNotification(data.error || 'Could not apply the update', true);
         }
       }).catch(function (err) {
         btn.disabled = false;
-        btn.textContent = 'Apply update';
+        btn.textContent = label;
         showNotification('Error: ' + err.message, true);
       });
     });
@@ -657,7 +675,11 @@
   }
 
   function makeInstallButton(label, extUrl, extName, extDir, catalogToken) {
-    var isSwitch = label.indexOf('Switch') === 0;
+    // "Download from <branch>" moves between sources like Switch does, so it
+    // gets the same colour — the green install button should mean "this is not
+    // installed yet", nothing else.
+    var isDownload = label.indexOf('Download') === 0;
+    var isSwitch = label.indexOf('Switch') === 0 || label.indexOf('Download from') === 0;
     var variant = label === 'Update' ? 'ext-mgr-update' : (isSwitch ? 'ext-mgr-switch' : 'ext-mgr-install');
     var btn = document.createElement('button');
     btn.type = 'button';
@@ -665,7 +687,10 @@
     btn.textContent = label;
     btn.addEventListener('click', function () {
       btn.disabled = true;
-      btn.textContent = label === 'Install' ? 'Installing...' : (isSwitch ? 'Switching...' : 'Updating...');
+      btn.textContent = label === 'Install' ? 'Installing...'
+        : isDownload ? 'Downloading...'
+        : isSwitch ? 'Switching...'
+        : 'Updating...';
 
       var params = {};
       if (extDir && catalogToken) {


### PR DESCRIPTION
Reported from a live instance:

```
Extension Manager | 0.6.1 develop | 0.6.1 | Install, update, and remove... | (self)
```

Installed from `develop`, viewing `main` at the same version, and the action cell offers nothing. That is exactly the one-way door #23 removed — for every extension except the one it was written in.

## Cause

#23 changed the action cell to key on **origin** rather than version order, but `selfAction()` has its own branch and still asked only "is a newer version available?". So the Installed column knew the origin differed — that is what prints `0.6.1 develop` — while the cell beside it fell through to `(self)`.

## Change

The self row now applies the same test as every other row: an installed copy whose origin is not this section's source can be moved here whatever the version order says.

Self-replacement still cannot be a copy over the running tree, so the move goes through the same two steps, named for what they do:

- **Download from `<branch>`** — stages and verifies, as Download update does
- **Apply switch** — not "Apply update", because moving between branches is frequently a downgrade

`Download from …` also takes the switch colour rather than the green install colour; green should mean "not installed yet" and nothing else.

## Decision table

Installed 0.6.1 from `develop`:

| section | action |
|---|---|
| `main`, 0.6.1 (the reported row) | **Download from main** |
| `develop` (its own origin) | `(self)` |
| `develop`, 0.6.2 available | Download update |
| `main`, older than installed | **Download from main** |
| staged from `main` | **Apply switch** — "0.6.1 from main verified" |
| staged from `develop`, newer | Apply update — "0.6.2 from develop verified" |
| install with no recorded origin | unchanged |

Version bumped 0.6.1 → 0.6.2, which also gives the running 0.6.1 something newer to exercise Download update against.