### PR TITLE
fix(extmgr): show Apply only where the copy was staged from

### DIFF
--- a/xExtension-ExtensionManager/README.md
+++ b/xExtension-ExtensionManager/README.md
@@ -102,6 +102,8 @@ Extension Manager moves between branches the same way every other extension does
 
 The switch still needs the two steps, because self-replacement can never be a copy over the running tree: **Switch to `<branch>`** stages and verifies, then **Apply switch** performs the swap. Only a genuinely higher version on the branch you are already on is offered as **Download update**.
 
+There is one staging area, not one per source, so Apply appears only in the section the staged copy came from. Other sections show `staged from <branch>` instead — apply or discard it there first.
+
 **What this cannot do:** if a staged copy is broken in a way the verifier does not catch, the code that would roll it back is the code that is broken. That is why verification happens before the swap and why the previous version is kept — recovery is one `mv`, not a reinstall.
 
 If the extensions directory is not writable, the update is queued instead and `install-queued.sh` performs the same swap out of band.

--- a/xExtension-ExtensionManager/metadata.json
+++ b/xExtension-ExtensionManager/metadata.json
@@ -2,7 +2,7 @@
     "name": "Extension Manager",
     "author": "featurecreep-cron",
     "description": "Install, update, and remove extensions from the settings page",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "entrypoint": "ExtensionManager",
     "type": "user"
 }

--- a/xExtension-ExtensionManager/static/script.js
+++ b/xExtension-ExtensionManager/static/script.js
@@ -579,6 +579,20 @@
   // is a reload, even though applying ends in one.
   function selfAction(ext, info, catalogToken) {
     if (pendingSelf) {
+      // There is one staged copy, not one per section, so Apply belongs only to
+      // the section it came from. Rendering it everywhere made every source
+      // look like it had something waiting, and two sections offering to apply
+      // different things is a claim the staging area cannot honour.
+      var stagedHere = (pendingSelf.source || null) === (ext.url || null) &&
+        (pendingSelf.branch || null) === (ext.branch || null);
+      if (!stagedHere) {
+        var elsewhere = document.createElement('span');
+        elsewhere.className = 'ext-mgr-staged-note';
+        elsewhere.textContent = 'staged from ' + (pendingSelf.branch || 'another source');
+        elsewhere.title = 'Only one copy can be staged at a time — apply or discard it in that section first';
+        return elsewhere;
+      }
+
       var wrap = document.createElement('span');
       wrap.className = 'ext-mgr-self-pending';
       // Applying a copy from a different branch is a move, not an upgrade, and


### PR DESCRIPTION
Reported from a live instance: downloading an update from `main` put an **Apply** button in the `develop` section as well.

## Cause

There is one staging area, not one per source, but `selfAction()` rendered the pending state in every section — so each row implied its own branch had something waiting, and only one of them was true. Clicking Apply from the develop row would have applied main's copy.

## Change

Apply and Discard belong to the section whose source matches the staged copy. Everywhere else reads `staged from <branch>` with no button — which is what is actually true: something is staged, from somewhere else, and that is where it gets applied or discarded.

Discard stays available in the owning section, so changing your mind is still one click; it just happens where the copy actually is.

## Decision table

Installed 0.6.1 from `develop`, staged from `main`:

| section | before | after |
|---|---|---|
| `main` | Apply switch + Discard | Apply switch + Discard |
| `develop` | **Apply update** ← wrong | `staged from main` |

Staged from `develop` instead:

| section | after |
|---|---|
| `develop` | Apply update + Discard |
| `main` | `staged from develop` |

Nothing staged: `main` → Switch to main, `develop` → Download update. Unchanged.

Version bumped 0.6.3 → 0.6.4.