### PR TITLE
fix(extmgr): only offer a switch when the other branch differs

### DIFF
--- a/xExtension-ExtensionManager/README.md
+++ b/xExtension-ExtensionManager/README.md
@@ -72,6 +72,8 @@ In a section whose branch is not the one the installed copy came from, the actio
 
 The switch is offered on the difference in origin, not on version order — you can move back to a branch that is behind the one you are on, which is the usual case after testing something on `develop`. Because that can be a downgrade, the button is coloured differently from Install and Update.
 
+It is only offered when it would change something you can see. A side branch holding the same version as your install is the same code, so that row stays quiet rather than advertising a move to identical files — with one exception: `main`/`master` always offers a way back, so an install that has drifted onto a branch is never stranded there. A side branch therefore reappears as a switch as soon as it is genuinely ahead or behind.
+
 An extension installed before source tracking existed has no recorded origin. Those keep the old behaviour — Update when a newer version is available — since an install that cannot be placed is not evidence that it came from somewhere else.
 
 ## Updating Extension Manager itself

--- a/xExtension-ExtensionManager/metadata.json
+++ b/xExtension-ExtensionManager/metadata.json
@@ -2,7 +2,7 @@
     "name": "Extension Manager",
     "author": "featurecreep-cron",
     "description": "Install, update, and remove extensions from the settings page",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "entrypoint": "ExtensionManager",
     "type": "user"
 }

--- a/xExtension-ExtensionManager/static/script.js
+++ b/xExtension-ExtensionManager/static/script.js
@@ -539,19 +539,14 @@
       } else if (info) {
         // Only one copy can be installed, so a section whose source is not the
         // one the installed copy came from offers a switch rather than an
-        // update. Without this the action cell keys on version alone: with the
-        // same version on both branches it shows a bare "Installed" badge and
-        // there is no way back, and with the other branch ahead the comparison
-        // is against a version this section does not have. Origin unknown
-        // (installed before source markers, no sidecar) falls through to the
-        // version comparison \u2014 an install we cannot place is not evidence that
-        // it came from somewhere else.
-        var originKnown = !!(info.source || info.branch);
-        var fromOtherSource = originKnown &&
-          ((info.source || null) !== (ext.url || null) || (info.branch || null) !== (ext.branch || null));
+        // update \u2014 see branchMoveLabel() for when that offer is worth making.
+        // Origin unknown (installed before source markers, no sidecar) falls
+        // through to the version comparison: an install we cannot place is not
+        // evidence that it came from somewhere else.
+        var moveLabel = branchMoveLabel(info, ext);
 
-        if (isAdmin && fromOtherSource) {
-          tdAction.appendChild(makeInstallButton('Switch to ' + (ext.branch || 'this source'), null, ext.name, ext.dir, catalogToken));
+        if (isAdmin && moveLabel) {
+          tdAction.appendChild(makeInstallButton(moveLabel, null, ext.name, ext.dir, catalogToken));
         } else if (isAdmin && compareVersions(String(ext.version), info.version) > 0) {
           tdAction.appendChild(makeInstallButton('Update', null, ext.name, ext.dir, catalogToken));
         } else {
@@ -577,6 +572,32 @@
   // verifies a copy alongside the running one, Apply update swaps them at the
   // start of the next request. Each button says what it does; neither of them
   // is a reload, even though applying ends in one.
+  // The one place that decides whether a row offers to move between sources.
+  // Both the ordinary rows and the Extension Manager row call it — last time
+  // the self row had its own copy of this test, it kept a one-way door through
+  // two releases.
+  //
+  // Origin differing is not on its own a reason to offer anything: with develop
+  // fast-forwarded to main, every row was offering to switch to byte-identical
+  // code, which reads as an available update. So the offer needs a difference
+  // the user can see — a different version — with one exception: the release
+  // branch always offers a way back, or an install that has drifted onto a side
+  // branch at the same version has no route home.
+  function branchMoveLabel(info, ext) {
+    var originKnown = !!(info && (info.source || info.branch));
+    if (!originKnown) return null;
+
+    var differentSource = (info.source || null) !== (ext.url || null) ||
+      (info.branch || null) !== (ext.branch || null);
+    if (!differentSource) return null;
+
+    var versionsDiffer = compareVersions(String(ext.version), String(info.version)) !== 0;
+    var isReleaseBranch = ext.branch === 'main' || ext.branch === 'master';
+    if (!versionsDiffer && !isReleaseBranch) return null;
+
+    return 'Switch to ' + (ext.branch || 'this source');
+  }
+
   function selfAction(ext, info, catalogToken) {
     if (pendingSelf) {
       // There is one staged copy, not one per section, so Apply belongs only to
@@ -614,30 +635,20 @@
     }
 
     var newer = info && compareVersions(String(ext.version), info.version) > 0;
-    // Same test the other rows use: an installed copy whose origin is not this
-    // section's source can be moved here whatever the version order says. This
-    // row used to check the version alone, which left Extension Manager with
-    // exactly the one-way door that branch switching was added to remove —
-    // installed from develop, viewing main at the same version, no way back.
-    var originKnown = !!(info && (info.source || info.branch));
-    var fromOtherSource = originKnown &&
-      ((info.source || null) !== (ext.url || null) || (info.branch || null) !== (ext.branch || null));
+    // A move between sources is named for the move, never "update" — the other
+    // branch is usually level or behind, so anything reading like an update
+    // advertises one that does not exist.
+    var moveLabel = branchMoveLabel(info, ext);
 
-    if (isAdmin && isWritable && (newer || fromOtherSource)) {
-      // Origin wins over version here. A different branch is a move, and
-      // labelling it "Download update" advertises an update that does not
-      // exist — the same word every other row uses for a switch is the honest
-      // one, even though ours needs a second step to finish. Only a genuinely
-      // higher version on our own branch is an update.
-      var label = fromOtherSource ? 'Switch to ' + (ext.branch || 'this source') : 'Download update';
-      return makeInstallButton(label, null, ext.name, ext.dir, catalogToken);
+    if (isAdmin && isWritable && (newer || moveLabel)) {
+      return makeInstallButton(moveLabel || 'Download update', null, ext.name, ext.dir, catalogToken);
     }
 
     var badge = document.createElement('span');
     badge.className = 'ext-mgr-installed-badge';
     // Without a writable extensions directory the swap cannot happen at all,
     // and saying "(self)" would hide the reason.
-    badge.textContent = (newer || fromOtherSource) && !isWritable
+    badge.textContent = (newer || moveLabel) && !isWritable
       ? 'available — run install-queued.sh'
       : '(self)';
     return badge;


### PR DESCRIPTION
Reported from a live instance — with `develop` fast-forwarded to `main`, every row in the develop section offered **Switch to develop**, to byte-identical code:

| section | Extension Manager | Right-Click Actions | Sticky Reader |
|---|---|---|---|
| `…/freshrss-extensions` | 0.6.4 → `(self)` | 0.1.7 → ✓ Installed | 0.3.2 → ✓ Installed |
| `…/freshrss-extensions develop` | 0.6.4 main → **Switch to develop** | 0.1.7 main → **Switch to develop** | 0.3.2 main → **Switch to develop** |

Same versions in both columns, same commit behind both sources. Three buttons implying something was waiting. It is the same defect as labelling a branch move "Download from" — a control promising a difference that does not exist.

## Change

A move is offered only when it changes something visible — a different version — with one exception: **`main`/`master` always offers a way back**, or an install that has drifted onto a side branch at the same version has no route home, which was the entire point of #25.

The test now lives in one function, `branchMoveLabel()`, used by both the ordinary rows and the Extension Manager row. The last time the self row kept its own copy of this logic, it kept a one-way door through two releases (#25).

## Trade-off, deliberate

You can no longer move *onto* a side branch that is level with your install. At that moment it offers nothing — same code — and it reappears the instant that branch is ahead or behind.

## Cases

| state | section | action |
|---|---|---|
| on `main`, develop level | develop | *(quiet)* — the reported bug |
| on `main`, develop at 0.6.5 | develop | Switch to develop |
| on `main`, main newer | main | Download update |
| on `develop`, main level | main | **Switch to main** (#25 case, preserved) |
| on `develop`, main behind | main | Switch to main |
| on `develop`, develop section | develop | *(quiet)* |
| no origin marker | any | unchanged — version comparison |

Version bumped 0.6.4 → 0.6.5, which also puts develop genuinely ahead so the switch can be exercised.