### PR TITLE
feat(quickfilter): choose what a keyword matches, and make the launcher a funnel

### DIFF
--- a/xExtension-QuickFilter/Controllers/quickfilterController.php
+++ b/xExtension-QuickFilter/Controllers/quickfilterController.php
@@ -29,7 +29,8 @@ final class FreshExtension_quickfilter_Controller extends Minz_ActionController 
     /**
      * POST ?c=quickfilter&a=add
      * Add a filter to a feed.
-     * Params: feedId, type (author|tag|keyword), value, action (read|star)
+     * Params: feedId, type (author|tag|keyword), value, action (read|star),
+     *         scope (title|article|both, keywords only, default title)
      */
     public function addAction(): void {
         if (!Minz_Request::isPost()) {
@@ -46,7 +47,7 @@ final class FreshExtension_quickfilter_Controller extends Minz_ActionController 
         }
 
         try {
-            $result = QuickFilterService::addFilter($feedId, $type, $value, $action);
+            $result = QuickFilterService::addFilter($feedId, $type, $value, $action, $this->scopeParam());
             $this->sendJson(['success' => true, 'filters' => $result['filters']]);
         } catch (InvalidArgumentException $e) {
             $this->sendJson(['error' => $e->getMessage()], 400);
@@ -56,7 +57,8 @@ final class FreshExtension_quickfilter_Controller extends Minz_ActionController 
     /**
      * POST ?c=quickfilter&a=remove
      * Remove a filter from a feed.
-     * Params: feedId, type (author|tag|keyword), value, action (read|star)
+     * Params: feedId, type (author|tag|keyword), value, action (read|star),
+     *         scope (title|article|both, keywords only, default title)
      */
     public function removeAction(): void {
         if (!Minz_Request::isPost()) {
@@ -73,7 +75,7 @@ final class FreshExtension_quickfilter_Controller extends Minz_ActionController 
         }
 
         try {
-            $result = QuickFilterService::removeFilter($feedId, $type, $value, $action);
+            $result = QuickFilterService::removeFilter($feedId, $type, $value, $action, $this->scopeParam());
             $this->sendJson(['success' => true, 'filters' => $result['filters']]);
         } catch (InvalidArgumentException $e) {
             $this->sendJson(['error' => $e->getMessage()], 400);
@@ -113,7 +115,7 @@ final class FreshExtension_quickfilter_Controller extends Minz_ActionController 
         }
 
         try {
-            $result = QuickFilterService::previewMatches($feedId, $type, $value);
+            $result = QuickFilterService::previewMatches($feedId, $type, $value, scope: $this->scopeParam());
             $this->sendJson($result);
         } catch (InvalidArgumentException $e) {
             $this->sendJson(['error' => $e->getMessage()], 400);
@@ -141,11 +143,20 @@ final class FreshExtension_quickfilter_Controller extends Minz_ActionController 
         }
 
         try {
-            $result = QuickFilterService::applyToExisting($feedId, $type, $value, $action, $offset);
+            $result = QuickFilterService::applyToExisting($feedId, $type, $value, $action, $offset, scope: $this->scopeParam());
             $this->sendJson(['success' => true] + $result);
         } catch (InvalidArgumentException $e) {
             $this->sendJson(['error' => $e->getMessage()], 400);
         }
+    }
+
+    /**
+     * Keyword scope, defaulting to title so a client that does not send one keeps
+     * the behaviour every filter had before scopes existed. The service validates
+     * the value; an unknown one is a 400, not a silent fallback.
+     */
+    private function scopeParam(): string {
+        return Minz_Request::paramString('scope') ?: QuickFilterService::SCOPE_TITLE;
     }
 
     private function sendJson(array $data, int $code = 200): never {

--- a/xExtension-QuickFilter/configure.phtml
+++ b/xExtension-QuickFilter/configure.phtml
@@ -2,8 +2,10 @@
       method="post">
     <input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>">
     <div class="form-group">
-        <p>QuickFilter adds inline filter controls to your article view. Star or auto-read articles by author, tag, or keyword.</p>
-        <p>Filter icons appear next to author names and tags. Use the gear icon in the nav bar to open the filter manager.</p>
+        <p>QuickFilter adds inline filter controls to your article view. Star or auto-read articles by author, tag, or keyword. Every rule it writes is an ordinary FreshRSS filter action on the feed, so anything you add here is visible and editable in the feed&rsquo;s own settings.</p>
+        <p>&#9734;/&#10003; controls appear next to author names and tags while the pointer is over an article. Tag controls need <em>Show tags</em> turned on in your display settings.</p>
+        <p>The funnel icon in the nav bar opens the filter manager, which is the only place keyword filters can be created. It needs a single feed open &mdash; from a category or &ldquo;all articles&rdquo; there is no feed to attach a rule to.</p>
+        <p>A keyword filter matches the <strong>title</strong>, the <strong>article body</strong>, or <strong>either</strong>. Title is the default. FreshRSS matches all three as case-insensitive substrings, as articles arrive &mdash; use <em>Apply to past articles</em> for ones already fetched.</p>
     </div>
     <div class="form-group form-actions">
         <button type="submit" class="btn btn-important">Save</button>

--- a/xExtension-QuickFilter/lib/QuickFilterService.php
+++ b/xExtension-QuickFilter/lib/QuickFilterService.php
@@ -9,6 +9,11 @@
  */
 class QuickFilterService {
 
+    /** Keyword scopes — which part of an article the keyword is matched against */
+    public const SCOPE_TITLE = 'title';
+    public const SCOPE_ARTICLE = 'article';
+    public const SCOPE_BOTH = 'both';
+
     /** FreshRSS uses semicolons to delimit multiple authors */
     private const AUTHOR_DELIMITERS = [';', ' · '];
 
@@ -33,6 +38,7 @@ class QuickFilterService {
                     $filters[] = [
                         'type' => $parsed['type'],
                         'value' => $parsed['value'],
+                        'scope' => $parsed['scope'] ?? null,
                         'action' => $action,
                         'search' => $searchStr,
                     ];
@@ -41,6 +47,7 @@ class QuickFilterService {
                     $filters[] = [
                         'type' => 'raw',
                         'value' => $searchStr,
+                        'scope' => null,
                         'action' => $action,
                         'search' => $searchStr,
                     ];
@@ -57,9 +64,9 @@ class QuickFilterService {
      * @return array{filters: array} Updated filter list on success
      * @throws InvalidArgumentException on invalid input
      */
-    public static function addFilter(int $feedId, string $type, string $value, string $action): array {
+    public static function addFilter(int $feedId, string $type, string $value, string $action, string $scope = self::SCOPE_TITLE): array {
         self::validateAction($action);
-        $filterString = self::buildFilterString($type, $value);
+        $filterString = self::buildFilterString($type, $value, $scope);
 
         $feed = self::loadFeed($feedId);
         if (!$feed) {
@@ -69,8 +76,11 @@ class QuickFilterService {
         // Read existing filter strings for this action
         $existing = self::getFilterStrings($feed, $action);
 
-        // Check for duplicate
-        if (in_array($filterString, $existing, true)) {
+        // Compare in parsed form, not as written. Search::quote() only quotes values
+        // that need it, so the intitle:"Boeing" we write comes back from core as
+        // intitle:Boeing — a raw string compare never matches and appends the same
+        // rule on every use.
+        if (self::containsFilter($existing, $filterString)) {
             return self::getFilters($feedId);
         }
 
@@ -86,7 +96,7 @@ class QuickFilterService {
      *
      * @return array{filters: array} Updated filter list
      */
-    public static function removeFilter(int $feedId, string $type, string $value, string $action): array {
+    public static function removeFilter(int $feedId, string $type, string $value, string $action, string $scope = self::SCOPE_TITLE): array {
         self::validateAction($action);
 
         $feed = self::loadFeed($feedId);
@@ -100,7 +110,7 @@ class QuickFilterService {
         if ($type === 'raw') {
             $targetSearch = $value;
         } else {
-            $targetSearch = self::buildFilterString($type, $value);
+            $targetSearch = self::buildFilterString($type, $value, $scope);
         }
 
         // Normalize via BooleanSearch so we match regardless of quoting style
@@ -118,23 +128,11 @@ class QuickFilterService {
     }
 
     /**
-     * Count articles matching a filter for preview/retroactive apply.
-     */
-    public static function countMatches(int $feedId, string $type, string $value): int {
-        $entryDAO = FreshRSS_Factory::createEntryDao();
-        $conditions = self::buildMatchConditions($type, $value);
-
-        return $entryDAO->countUnreadReadFavorites()['all'] ?? 0;
-        // TODO: Need custom query — FreshRSS EntryDAO doesn't expose
-        // a count-by-filter method. Implement in applyToExisting instead.
-    }
-
-    /**
      * Apply a filter retroactively to existing articles.
      *
      * @return array{applied: int, total: int} Count of affected articles
      */
-    public static function applyToExisting(int $feedId, string $type, string $value, string $action, int $offset = 0, int $batchSize = 50): array {
+    public static function applyToExisting(int $feedId, string $type, string $value, string $action, int $offset = 0, int $batchSize = 50, string $scope = self::SCOPE_TITLE): array {
         self::validateAction($action);
 
         $feed = self::loadFeed($feedId);
@@ -145,7 +143,7 @@ class QuickFilterService {
         $entryDAO = FreshRSS_Factory::createEntryDao();
 
         // Build search for matching entries
-        $filterString = self::buildFilterString($type, $value);
+        $filterString = self::buildFilterString($type, $value, $scope);
         $search = new FreshRSS_BooleanSearch($filterString);
 
         // Use FreshRSS's built-in search to find matching entries
@@ -188,8 +186,8 @@ class QuickFilterService {
      *
      * @return array{count: int, articles: array}
      */
-    public static function previewMatches(int $feedId, string $type, string $value, int $limit = 50): array {
-        $filterString = self::buildFilterString($type, $value);
+    public static function previewMatches(int $feedId, string $type, string $value, int $limit = 50, string $scope = self::SCOPE_TITLE): array {
+        $filterString = self::buildFilterString($type, $value, $scope);
         $search = new FreshRSS_BooleanSearch($filterString);
         $entryDAO = FreshRSS_Factory::createEntryDao();
 
@@ -323,6 +321,25 @@ class QuickFilterService {
         return $strings;
     }
 
+    /**
+     * @param string[] $existing
+     */
+    private static function containsFilter(array $existing, string $filterString): bool {
+        $targetNorm = (new FreshRSS_BooleanSearch($filterString))->__toString();
+        foreach ($existing as $s) {
+            if ((new FreshRSS_BooleanSearch($s))->__toString() === $targetNorm) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static function validateScope(string $scope): void {
+        if (!in_array($scope, [self::SCOPE_TITLE, self::SCOPE_ARTICLE, self::SCOPE_BOTH], true)) {
+            throw new InvalidArgumentException('Invalid scope: ' . $scope);
+        }
+    }
+
     private static function validateAction(string $action): void {
         if (!in_array($action, ['read', 'star'], true)) {
             throw new InvalidArgumentException('Invalid action: ' . $action);
@@ -332,7 +349,7 @@ class QuickFilterService {
     /**
      * Build a FreshRSS filter string from structured input.
      */
-    public static function buildFilterString(string $type, string $value): string {
+    public static function buildFilterString(string $type, string $value, string $scope = self::SCOPE_TITLE): string {
         $value = trim($value);
         if ($value === '') {
             throw new InvalidArgumentException('Filter value cannot be empty');
@@ -356,9 +373,38 @@ class QuickFilterService {
                 if (strlen($value) > 200) {
                     throw new InvalidArgumentException('Keyword must be at most 200 characters');
                 }
-                // Double-quote keywords (FreshRSS convention)
+                // Scope decides which operator carries the keyword. FreshRSS matches
+                // all three the same way at fetch time — case-insensitive substring —
+                // and differs only in what it looks at: intitle: the title, intext: the
+                // content, a bare term either of them (Entry::matches()).
+                self::validateScope($scope);
                 $escaped = str_replace('"', '\\"', $value);
-                return 'intitle:"' . $escaped . '"';
+                switch ($scope) {
+                    case self::SCOPE_ARTICLE:
+                        return 'intext:"' . $escaped . '"';
+                    case self::SCOPE_BOTH:
+                        // A bare term is the only form with no operator in front of it,
+                        // so a value that looks like one is indistinguishable from one
+                        // after the round trip: core stores "#rust" and "author:foo"
+                        // correctly, but Search::__toString() drops the quotes it no
+                        // longer needs, and the rule reads back as a tag or an author.
+                        // The filter still matches the right articles; the row above it
+                        // would name the wrong kind of rule and preview the wrong query.
+                        // Refused rather than silently mislabelled — the other two
+                        // scopes carry a prefix and are safe.
+                        if (preg_match('/^[#!-]|^[A-Za-z]+:/', $value) === 1) {
+                            throw new InvalidArgumentException(
+                                'A title-or-body keyword cannot start with # or - or contain '
+                                . 'a word followed by a colon: FreshRSS reads those as search '
+                                . 'operators. Use the Title or Article body scope instead.'
+                            );
+                        }
+                        // Quoted so a multi-word value stays one phrase. Unquoted, core
+                        // splits a bare term on spaces into separate AND-ed needles.
+                        return '"' . $escaped . '"';
+                    default:
+                        return 'intitle:"' . $escaped . '"';
+                }
 
             default:
                 throw new InvalidArgumentException('Invalid filter type: ' . $type);
@@ -366,8 +412,11 @@ class QuickFilterService {
     }
 
     /**
-     * Parse a filter string back into type + value.
-     * @return array{type: string, value: string}|null
+     * Parse a filter string back into type + value (+ scope, for keywords).
+     *
+     * Anything not recognised returns null and is shown as a raw rule rather than
+     * being rewritten — a hand-written boolean expression is not ours to reshape.
+     * @return array{type: string, value: string, scope?: string}|null
      */
     public static function parseFilterString(string $search): ?array {
         $search = trim($search);
@@ -388,17 +437,49 @@ class QuickFilterService {
             return ['type' => 'tag', 'value' => str_replace('+', ' ', $m[1])];
         }
 
-        // intitle:"keyword" or intitle:'keyword' or intitle:keyword
+        // intitle:"keyword" or intitle:'keyword' or intitle:keyword — title only
         if (preg_match('/^intitle:"(.+)"$/', $search, $m)) {
-            return ['type' => 'keyword', 'value' => str_replace('\\"', '"', $m[1])];
+            return self::keyword(str_replace('\\"', '"', $m[1]), self::SCOPE_TITLE);
         }
         if (preg_match("/^intitle:'(.+)'$/", $search, $m)) {
-            return ['type' => 'keyword', 'value' => str_replace("\\'", "'", $m[1])];
+            return self::keyword(str_replace("\\'", "'", $m[1]), self::SCOPE_TITLE);
         }
         if (preg_match('/^intitle:(\S+)$/', $search, $m)) {
-            return ['type' => 'keyword', 'value' => $m[1]];
+            return self::keyword($m[1], self::SCOPE_TITLE);
+        }
+
+        // intext:"keyword" and friends — article body only
+        if (preg_match('/^intext:"(.+)"$/', $search, $m)) {
+            return self::keyword(str_replace('\\"', '"', $m[1]), self::SCOPE_ARTICLE);
+        }
+        if (preg_match("/^intext:'(.+)'$/", $search, $m)) {
+            return self::keyword(str_replace("\\'", "'", $m[1]), self::SCOPE_ARTICLE);
+        }
+        if (preg_match('/^intext:(\S+)$/', $search, $m)) {
+            return self::keyword($m[1], self::SCOPE_ARTICLE);
+        }
+
+        // A bare term matches title or content. Recognised last and conservatively:
+        // an unquoted term is only ours if it carries no operator syntax at all, so
+        // f:70, -word, boolean groups and the like stay raw instead of being
+        // mislabelled as a keyword we could rewrite.
+        if (preg_match('/^"(.+)"$/', $search, $m)) {
+            return self::keyword(str_replace('\\"', '"', $m[1]), self::SCOPE_BOTH);
+        }
+        if (preg_match("/^'(.+)'$/", $search, $m)) {
+            return self::keyword(str_replace("\\'", "'", $m[1]), self::SCOPE_BOTH);
+        }
+        if (preg_match('/^(?![-!])([^\s:#"\'()]+)$/', $search, $m)) {
+            return self::keyword($m[1], self::SCOPE_BOTH);
         }
 
         return null;
+    }
+
+    /**
+     * @return array{type: string, value: string, scope: string}
+     */
+    private static function keyword(string $value, string $scope): array {
+        return ['type' => 'keyword', 'value' => $value, 'scope' => $scope];
     }
 }

--- a/xExtension-QuickFilter/metadata.json
+++ b/xExtension-QuickFilter/metadata.json
@@ -2,7 +2,7 @@
     "name": "QuickFilter",
     "author": "featurecreep-cron",
     "description": "Build filters from article context — star or hide articles by author, tag, or keyword",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "entrypoint": "QuickFilter",
     "type": "user"
 }

--- a/xExtension-QuickFilter/static/script.js
+++ b/xExtension-QuickFilter/static/script.js
@@ -44,6 +44,10 @@
 
   // ========== Filter Map ==========
 
+  function keywordKey(value, scope) {
+    return (scope || 'title') + '\u0000' + value.toLowerCase();
+  }
+
   function buildFilterMap() {
     filterMap = { authors: {}, tags: {}, keywords: {} };
     filters.forEach(function (f) {
@@ -52,7 +56,10 @@
       } else if (f.type === 'tag') {
         filterMap.tags[f.value.toLowerCase()] = { action: f.action, search: f.search };
       } else if (f.type === 'keyword') {
-        filterMap.keywords[f.value.toLowerCase()] = { action: f.action, search: f.search };
+        // Keyed by scope as well as value: "rust" in titles and "rust" in bodies
+        // are two different rules and must not overwrite each other here.
+        filterMap.keywords[keywordKey(f.value, f.scope)] =
+          { action: f.action, search: f.search, scope: f.scope || 'title', value: f.value };
       }
     });
   }
@@ -241,7 +248,11 @@
     activeBtn.disabled = true;
     otherBtn.disabled = true;
 
-    var key = value.toLowerCase();
+    // Keywords are keyed by scope + value now. Inline controls only ever exist for
+    // authors and tags, so this branch is unreachable today — left consistent
+    // anyway, because a lookup that silently misses is how the last two one-way
+    // doors in this repo survived a review.
+    var key = type === 'keyword' ? keywordKey(value, 'title') : value.toLowerCase();
     var mapObj = type === 'author' ? filterMap.authors :
                  type === 'tag' ? filterMap.tags : filterMap.keywords;
     var existing = mapObj[key];
@@ -342,18 +353,22 @@
   // ========== Title Keyword Highlighting ==========
 
   function highlightTitleKeywords(article) {
-    var keywords = Object.keys(filterMap.keywords);
-    if (keywords.length === 0) return;
+    // Only rules that read the title. Painting a match for an article-body rule
+    // would claim the title is why the article was filtered, which it was not.
+    // Iterated as entries, not keys: a key carries its scope, and the thing to
+    // search the title for is the keyword itself.
+    var rules = Object.keys(filterMap.keywords)
+      .map(function (k) { return filterMap.keywords[k]; })
+      .filter(function (info) { return info.scope !== 'article'; });
+    if (rules.length === 0) return;
 
     var titleEl = article.querySelector('.title .item-element');
     if (!titleEl) return;
 
-    var text = titleEl.textContent;
     var html = titleEl.innerHTML;
 
-    keywords.forEach(function (kw) {
-      var info = filterMap.keywords[kw];
-      var regex = new RegExp('(' + escapeRegex(kw) + ')', 'gi');
+    rules.forEach(function (info) {
+      var regex = new RegExp('(' + escapeRegex(info.value) + ')', 'gi');
       var cls = info.action === 'star' ? 'qf-highlight-positive' : 'qf-highlight-negative';
       html = html.replace(regex, '<span class="' + cls + '">$1</span>');
     });
@@ -404,7 +419,15 @@
     btn.type = 'button';
     btn.className = 'qf-manager-btn';
     btn.title = 'Manage filters';
-    btn.innerHTML = '&#9661;'; // ▽ filter
+    // A funnel, not a caret. This opens the filter manager; a down-pointing
+    // triangle reads as a drop-down menu that is about to unroll under it.
+    // Drawn inline rather than pulled from ../themes/icons — FreshRSS ships no
+    // filter glyph at 1.28 or 1.29 — and painted in currentColor so it takes
+    // the nav menu's colour in every theme.
+    btn.innerHTML = '<svg class="qf-manager-icon" viewBox="0 0 16 16" width="14" height="14" ' +
+      'aria-hidden="true" focusable="false"><path fill="currentColor" ' +
+      'd="M1.5 2h13a.5.5 0 0 1 .38.82L10 8.7V13a.5.5 0 0 1-.72.45l-2.5-1.25A.5.5 0 0 1 6.5 ' +
+      '11.75V8.7L1.12 2.82A.5.5 0 0 1 1.5 2z"/></svg>';
     btn.setAttribute('aria-label', 'Open filter manager');
     btn.addEventListener('click', function () {
       if (feedId <= 0) {
@@ -497,7 +520,10 @@
 
         var desc = document.createElement('span');
         desc.className = 'qf-rule-desc';
-        desc.textContent = f.type + ': ' + f.value;
+        // A keyword row without its scope is the bug this release fixes, one step
+        // removed: two rules reading "keyword: rust" that behave differently.
+        desc.textContent = f.type + ': ' + f.value +
+          (f.type === 'keyword' && f.scope ? ' (' + scopeLabel(f.scope) + ')' : '');
         li.appendChild(desc);
 
         var actions = document.createElement('span');
@@ -508,7 +534,7 @@
         runBtn.className = 'qf-btn-small';
         runBtn.textContent = 'Apply to past articles';
         runBtn.addEventListener('click', function () {
-          openPreview(f.type, f.value, f.action);
+          openPreview(f.type, f.value, f.action, false, f.scope || null);
         });
         actions.appendChild(runBtn);
 
@@ -518,12 +544,14 @@
         delBtn.textContent = 'Delete';
         delBtn.addEventListener('click', function () {
           if (!confirm('Remove filter: ' + f.type + ' "' + f.value + '"?')) return;
-          serializedApiCall('remove', {
+          var params = {
             feedId: feedId,
             type: f.type,
             value: f.value,
             action: f.action,
-          }).then(function (data) {
+          };
+          if (f.scope) params.scope = f.scope;
+          serializedApiCall('remove', params).then(function (data) {
             if (data.filters) {
               updateFiltersFromServer(data.filters);
               refreshPanel();
@@ -592,6 +620,26 @@
     valueRow.appendChild(valueInput);
     formFields.appendChild(valueRow);
 
+    // Scope selector — keywords only. Author and tag have nothing to scope: core
+    // matches them against their own fields. Default title, which is what every
+    // keyword filter written before this existed already means.
+    var scopeRow = createFormRow('Match in');
+    var scopeSelect = document.createElement('select');
+    scopeSelect.className = 'qf-select qf-scope-select';
+    [
+      ['title', 'Title'],
+      ['article', 'Article body'],
+      ['both', 'Title or body']
+    ].forEach(function (pair) {
+      var opt = document.createElement('option');
+      opt.value = pair[0];
+      opt.textContent = pair[1];
+      scopeSelect.appendChild(opt);
+    });
+    scopeRow.appendChild(scopeSelect);
+    scopeRow.style.display = 'none';
+    formFields.appendChild(scopeRow);
+
     // Action selector
     var actionRow = createFormRow('Action');
     var actionSelect = document.createElement('select');
@@ -634,7 +682,7 @@
       var type = typeSelect.value;
       var value = type === 'keyword' ? valueInput.value.trim() : valueSelect.value;
       if (!value) { showNotification('Select a value', true); return; }
-      openPreview(type, value, actionSelect.value);
+      openPreview(type, value, actionSelect.value, false, currentScope(type, scopeSelect));
     });
     btnRow.appendChild(previewBtn);
 
@@ -652,18 +700,24 @@
       saveBtn.disabled = true;
       saveBtn.textContent = 'Saving...';
 
-      serializedApiCall('add', {
+      var scope = currentScope(type, scopeSelect);
+      var addParams = {
         feedId: feedId,
         type: type,
         value: value,
         action: action,
-      }).then(function (data) {
+      };
+      // Omitted rather than sent as null: URLSearchParams stringifies null to
+      // "null", which the server would read as a scope and reject.
+      if (scope) addParams.scope = scope;
+
+      serializedApiCall('add', addParams).then(function (data) {
         if (data.filters) {
           updateFiltersFromServer(data.filters);
 
           // Apply to existing if checked
           if (applyCheckbox.checked) {
-            openPreview(type, value, action, true);
+            openPreview(type, value, action, true, scope);
           }
 
           refreshPanel();
@@ -688,9 +742,11 @@
       if (typeSelect.value === 'keyword') {
         valueSelect.style.display = 'none';
         valueInput.style.display = '';
+        scopeRow.style.display = '';
       } else {
         valueSelect.style.display = '';
         valueInput.style.display = 'none';
+        scopeRow.style.display = 'none';
         populateValueDropdown(typeSelect.value, valueSelect);
       }
     });
@@ -757,15 +813,29 @@
 
   // ========== Preview ==========
 
-  function openPreview(type, value, action, autoApply) {
-    apiGet('preview', { feedId: feedId, type: type, value: value }).then(function (data) {
-      showPreviewDialog(type, value, action, data, autoApply);
+  // Scope is a property of keyword rules only. Sending one for an author or tag
+  // would be noise the server has to ignore, so it is dropped here rather than
+  // defended against on both sides.
+  function currentScope(type, scopeSelect) {
+    return type === 'keyword' ? scopeSelect.value : null;
+  }
+
+  function scopeLabel(scope) {
+    return scope === 'article' ? 'article body' :
+           scope === 'both' ? 'title or body' : 'title';
+  }
+
+  function openPreview(type, value, action, autoApply, scope) {
+    var params = { feedId: feedId, type: type, value: value };
+    if (scope) params.scope = scope;
+    apiGet('preview', params).then(function (data) {
+      showPreviewDialog(type, value, action, data, autoApply, scope);
     }).catch(function (err) {
       showNotification(err.error || 'Failed to load preview', true);
     });
   }
 
-  function showPreviewDialog(type, value, action, data, autoApply) {
+  function showPreviewDialog(type, value, action, data, autoApply, scope) {
     var overlay = document.createElement('div');
     overlay.className = 'qf-overlay';
 
@@ -774,7 +844,8 @@
     dialog.setAttribute('role', 'dialog');
 
     var title = document.createElement('h3');
-    title.textContent = data.count + ' articles match: ' + type + ' "' + value + '"';
+    title.textContent = data.count + ' articles match: ' + type + ' "' + value + '"' +
+      (scope ? ' in ' + scopeLabel(scope) : '');
     dialog.appendChild(title);
 
     if (data.articles && data.articles.length > 0) {
@@ -799,7 +870,7 @@
       applyBtn.addEventListener('click', function () {
         applyBtn.disabled = true;
         applyBtn.textContent = 'Applying...';
-        applyRetroactive(type, value, action, 0, function (total) {
+        applyRetroactive(type, value, action, 0, scope, function (total) {
           applyBtn.textContent = 'Applied to ' + total + ' articles';
           setTimeout(function () { overlay.remove(); }, 1500);
         });
@@ -825,16 +896,18 @@
     }
   }
 
-  function applyRetroactive(type, value, action, offset, onComplete) {
-    serializedApiCall('apply', {
+  function applyRetroactive(type, value, action, offset, scope, onComplete) {
+    var params = {
       feedId: feedId,
       type: type,
       value: value,
       action: action,
       offset: offset,
-    }).then(function (data) {
+    };
+    if (scope) params.scope = scope;
+    serializedApiCall('apply', params).then(function (data) {
       if (data.hasMore) {
-        applyRetroactive(type, value, action, data.offset, onComplete);
+        applyRetroactive(type, value, action, data.offset, scope, onComplete);
       } else {
         onComplete(data.offset);
       }
@@ -850,7 +923,10 @@
 
     var banner = document.createElement('div');
     banner.className = 'qf-banner';
-    banner.innerHTML = '<span>QuickFilter: use the &#9734;/&#10003; icons next to authors and tags to create filters.</span>';
+    // Names both routes in. The old banner mentioned only the inline icons, which
+    // left keyword filters — the one thing reachable nowhere else — undiscoverable.
+    banner.innerHTML = '<span>QuickFilter: use the &#9734;/&#10003; icons next to authors ' +
+      'and tags, or the funnel icon in the nav bar for keyword filters.</span>';
 
     var dismiss = document.createElement('button');
     dismiss.type = 'button';

--- a/xExtension-QuickFilter/static/style.css
+++ b/xExtension-QuickFilter/static/style.css
@@ -161,6 +161,14 @@ a .qf-controls .qf-btn {
   transition: color 0.15s ease, background 0.15s ease;
 }
 
+/* The glyph is an inline SVG painted in currentColor, so it follows the button's
+   colour transitions on hover and focus without a second rule per state. */
+.qf-manager-icon {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+
 .qf-manager-btn:hover {
   color: var(--qf-text);
   background: var(--qf-hover-bg);
@@ -169,6 +177,13 @@ a .qf-controls .qf-btn {
 .qf-manager-btn:focus-visible {
   outline: 2px solid var(--qf-positive);
   outline-offset: 1px;
+}
+
+/* The scope row only exists for keyword filters, so it is hidden inline by the
+   script rather than by a class. This keeps its spacing identical to the rows it
+   sits between when it is shown. */
+.qf-scope-select {
+  width: 100%;
 }
 
 /* ── Filter Manager Panel ── */


### PR DESCRIPTION
Closes #29.

`brandnewant` set up a keyword filter expecting it to match the word anywhere in the article. It matched titles only — accurately, because every keyword rule QuickFilter has ever written was `intitle:"<value>"`, while the control that creates them says "keyword" and the field says *Enter keyword (min 3 chars)*. Neither mentions the title.

## What FreshRSS actually offers

Verified in core at **1.28.1** (Chris's instance) and **1.29.1** (the reporter's). Scope is three per-rule operators, all matched identically at fetch time — case-insensitive substring, in PHP, via `Entry::matches()` — differing only in what they read:

| operator | reads | `Entry::matches()` 1.28.1 / 1.29.1 |
|---|---|---|
| `intitle:"x"` | title | `:720` / `:750` |
| `intext:"x"` | content | `:740` / `:770` |
| `"x"` | title **or** content | `:832` / `:862` |

Filter actions never touch the search SQL, so none of this varies by database backend.

## Change

The add form gains a **Match in** row — Title / Article body / Title or body — shown only for `type = keyword`, since authors and tags have nothing to scope. It defaults to **Title**, so every rule saved before this release keeps its exact meaning and anyone who ignores the control gets today's behaviour.

Scope rides through add, remove, preview and apply-to-past, and comes back out of `parseFilterString()`, so an existing rule round-trips into the row that created it. Rules are listed with their scope — two rows both reading `keyword: rust` that behave differently is the reported defect one step removed.

The launcher glyph was `&#9661;`, a down-pointing triangle, which reads as a menu about to unroll under it. It opens the filter manager, so it is a funnel now: inline SVG in `currentColor`, because FreshRSS ships no filter icon at either version.

## Also fixed, all in code this change touches

- **The duplicate check never fired.** It compared filter strings as written, but `Search::quote()` only quotes values that need it, so the `intitle:"Boeing"` we write comes back from core as `intitle:Boeing` — and the same rule was appended on every use. Both sides compare parsed now. Same defect fixed in Right-Click Actions in #20.
- **Keyword highlighting keyed the filter map on value alone**, so `rust` in titles and `rust` in bodies overwrote each other. Keyed on scope + value now, and article-body rules no longer paint the title as the reason a rule matched.
- **`countMatches()` called `buildMatchConditions()`, which does not exist.** Nothing called `countMatches()`, so it was a fatal waiting for its first caller. Removed.
- **The configure page described a gear icon that has never been there**, and the onboarding banner named only the inline ☆/✓ controls — leaving the filter manager, the one place keyword filters can be created, undiscoverable. Chris had the extension installed and could not find it. Both now say where to click and what the manager needs (a single feed open).

## Deliberate refusal

A title-or-body keyword starting with `#` or `-`, or shaped like `word:`, is rejected with an explanation. The bare term is the only form with no operator in front of it: core stores `"#rust"` correctly and matches the right articles, but `Search::__toString()` drops quotes it no longer needs, and the rule reads back as a **tag**. The filter would work while the row above it named the wrong kind of rule and previewed the wrong query. The other two scopes carry a prefix and are unaffected.

## Verification

- `node --check` on `script.js`.
- No PHP available in this environment and no Docker to borrow one — **CI's PHP Lint 8.1/8.3 is the only syntax gate this has passed.** Not run against a live FreshRSS yet.

Version 0.1.3 → 0.2.0 (new user-facing capability, per the minor-bump precedent set by Extension Manager 0.5.0 and 0.6.0).