### PR TITLE
feat(rca): let the filter dialog choose what the keyword matches

### DIFF
--- a/xExtension-RightClickActions/README.md
+++ b/xExtension-RightClickActions/README.md
@@ -8,8 +8,9 @@ Adds context menus to articles, feeds, and categories in FreshRSS.
 
 - Right-click article headlines to toggle read/unread, star, open in new tab, or filter
 - Build a standing rule from an article you are looking at: **Hide articles like this** and
-  **Star articles like this** save a title filter on that feed, then apply it to the articles
-  already stored so the rule is not invisible until the next refresh
+  **Star articles like this** save a keyword filter on that feed — matching the title, the
+  article body, or either — then apply it to the articles already stored so the rule is not
+  invisible until the next refresh
 - Right-click sidebar feeds to mark all read/unread or open feed settings
 - Right-click sidebar categories to manage subscriptions, expand/collapse, or bulk-mark
 - Each context zone (headlines, article body, sidebar feeds, sidebar categories) can be toggled independently
@@ -23,17 +24,31 @@ Copy the `xExtension-RightClickActions` directory into your FreshRSS `extensions
 
 Four context zones, each independently togglable:
 
-- **Article headlines** -- toggle read, star, open in new tab, mark older/newer, hide or star by title keyword, show this feed only
+- **Article headlines** -- toggle read, star, open in new tab, mark older/newer, hide or star by keyword, show this feed only
 - **Article content** -- same actions as headlines, applied to the article body area
 - **Sidebar feeds** -- mark all read/unread, recently read, open settings
 - **Sidebar categories** -- mark all read/unread, recently read, expand/collapse, add/manage subscriptions
 
-## Title filters
+## Keyword filters
 
-Both title actions prompt with the article's title pre-filled, so you can cut it down to the
-part that should match. The result is saved as a filter action on that feed — `intitle:"…"`,
-quoted, because FreshRSS reads an unquoted `intitle:two words` as `intitle:two` plus a loose
-search for `words`.
+Both actions open a dialog with the article's title pre-filled and selected, so you can cut it
+down to the part that should match, and a **Match in** choice for where it should match.
+
+| choice | saved as | reads |
+|---|---|---|
+| the title | `intitle:"…"` | the headline |
+| the article body | `intext:"…"` | the stored content |
+| the title or the body | `"…"` | either |
+
+Values are quoted because FreshRSS reads an unquoted `intitle:two words` as `intitle:two` plus
+a loose search for `words`.
+
+Two things worth knowing about the wider scopes. `intext:` matches the article's stored HTML,
+so a keyword like `href` or `img` will match markup rather than prose. And a title-or-body
+keyword cannot start with `#` or `-`, or read as `word:` — the bare term is the only form with
+no operator in front of it, so FreshRSS cannot tell such a value from an operator once it
+re-serialises the rule. The dialog says so rather than saving something that would list itself
+as a different kind of filter.
 
 Filter actions normally only run against articles as they are fetched, so both actions also
 apply the rule once to articles already stored in that feed: hiding marks them read, starring

--- a/xExtension-RightClickActions/metadata.json
+++ b/xExtension-RightClickActions/metadata.json
@@ -2,7 +2,7 @@
     "name": "Right-Click Actions",
     "author": "featurecreep-cron",
     "description": "Adds context menus to articles, feeds, and categories",
-    "version": "0.1.7",
+    "version": "0.2.0",
     "entrypoint": "RightClickActions",
     "type": "user"
 }

--- a/xExtension-RightClickActions/static/script.js
+++ b/xExtension-RightClickActions/static/script.js
@@ -270,10 +270,46 @@
 
   // FreshRSS reads a bare `intitle:two words` as intitle:two AND a loose
   // "words", so a keyword lifted from an article title — which is exactly what
-  // the prompt pre-fills — has to be quoted or the saved rule matches far more
-  // than the user asked for. Mirrors QuickFilterService::buildFilterString().
-  function buildTitleFilter(keyword) {
-    return 'intitle:"' + keyword.replace(/"/g, '\\"') + '"';
+  // the dialog pre-fills — has to be quoted or the saved rule matches far more
+  // than the user asked for. Mirrors QuickFilterService::buildFilterString(),
+  // including which operator carries which scope: intitle: reads the title,
+  // intext: the stored content, a bare term either of them.
+  function buildKeywordFilter(keyword, scope) {
+    var escaped = keyword.replace(/"/g, '\\"');
+    if (scope === 'article') return 'intext:"' + escaped + '"';
+    if (scope === 'both') {
+      // The bare term is the only form with no operator in front of it, so a
+      // value shaped like one cannot be told apart from one after a round trip:
+      // FreshRSS stores "#rust" correctly and matches the right articles, but
+      // Search::__toString() drops quotes it no longer needs and the rule reads
+      // back as a tag. Refused rather than silently mislabelled.
+      if (/^[#!-]|^[A-Za-z]+:/.test(keyword)) {
+        throw new Error('A title-or-body keyword cannot start with # or - or contain a word ' +
+          'followed by a colon — FreshRSS reads those as search operators. Pick Title or ' +
+          'Article body instead.');
+      }
+      return '"' + escaped + '"';
+    }
+    return 'intitle:"' + escaped + '"';
+  }
+
+  // The article body is in the stream for every entry, not just the open one —
+  // app/views/helpers/index/article.phtml renders .text unconditionally inside
+  // .flux_content .content — so the on-page sweep can read it without opening
+  // anything. Note it reads rendered text while FreshRSS's own intext: matches
+  // the stored HTML, so the server, which has the last word, can match markup
+  // this cannot see.
+  function articleBodyText(flux) {
+    var el = flux.querySelector('.flux_content .content .text') ||
+             flux.querySelector('.content .text');
+    return el ? el.textContent : '';
+  }
+
+  function fluxMatches(flux, lowerKeyword, scope) {
+    var inTitle = articleTitleText(flux).toLowerCase().indexOf(lowerKeyword) !== -1;
+    if (scope === 'title') return inTitle;
+    var inBody = articleBodyText(flux).toLowerCase().indexOf(lowerKeyword) !== -1;
+    return scope === 'article' ? inBody : (inTitle || inBody);
   }
 
   // The title anchor is not only the title: FreshRSS nests its inline
@@ -292,40 +328,149 @@
     return text || a.textContent.trim();
   }
 
-  var FILTER_PROMPTS = {
-    read: 'Hide articles with titles containing:',
-    star: 'Star articles with titles containing:'
+  var FILTER_HEADINGS = {
+    read: 'Hide articles containing',
+    star: 'Star articles containing'
   };
+
+  var SCOPES = [
+    ['title', 'the title'],
+    ['article', 'the article body'],
+    ['both', 'the title or the body']
+  ];
+
+  // A native prompt() cannot carry a second control, and the old one had to name
+  // the title in its question because that was the only thing it could filter on.
+  // Now that scope is a choice, the question stops claiming to know the answer.
+  function openFilterDialog(action, prefill, onConfirm) {
+    // handleAction() runs before hideMenu(), so targetFlux is still set while this
+    // is called — but it is null by the time the dialog is confirmed. Everything
+    // the callback needs is captured by the caller before we get here; nothing
+    // below may read it.
+    var previousFocus = document.activeElement;
+
+    var overlay = document.createElement('div');
+    overlay.className = 'rca-overlay';
+
+    var dialog = document.createElement('div');
+    dialog.className = 'rca-dialog';
+    // Same theme test the context menu uses, for the same reason: FreshRSS themes
+    // do not expose a variable we can read, so the background is sampled.
+    if (isDark()) dialog.classList.add('frss-dark');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.setAttribute('aria-label', FILTER_HEADINGS[action]);
+
+    var heading = document.createElement('h3');
+    heading.className = 'rca-dialog-title';
+    heading.textContent = FILTER_HEADINGS[action];
+    dialog.appendChild(heading);
+
+    var input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'rca-dialog-input';
+    input.value = prefill || '';
+    dialog.appendChild(input);
+
+    var scopeLabel = document.createElement('label');
+    scopeLabel.className = 'rca-dialog-label';
+    scopeLabel.textContent = 'Match in';
+    var scopeSelect = document.createElement('select');
+    scopeSelect.className = 'rca-dialog-select';
+    SCOPES.forEach(function (pair) {
+      var opt = document.createElement('option');
+      opt.value = pair[0];
+      opt.textContent = pair[1];
+      scopeSelect.appendChild(opt);
+    });
+    scopeLabel.appendChild(scopeSelect);
+    dialog.appendChild(scopeLabel);
+
+    var actions = document.createElement('div');
+    actions.className = 'rca-dialog-actions';
+
+    var cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'rca-dialog-btn';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', close);
+    actions.appendChild(cancelBtn);
+
+    var okBtn = document.createElement('button');
+    okBtn.type = 'button';
+    okBtn.className = 'rca-dialog-btn rca-dialog-btn-primary';
+    okBtn.textContent = action === 'star' ? 'Star' : 'Hide';
+    okBtn.addEventListener('click', confirm);
+    actions.appendChild(okBtn);
+
+    dialog.appendChild(actions);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    // Selected, not just focused: the field is pre-filled with a whole headline
+    // and the usual next move is to cut it down to one word.
+    input.focus();
+    input.select();
+
+    overlay.addEventListener('mousedown', function (e) {
+      if (e.target === overlay) close();
+    });
+    dialog.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') { e.preventDefault(); close(); }
+      if (e.key === 'Enter' && e.target === input) { e.preventDefault(); confirm(); }
+    });
+
+    function close() {
+      if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+      if (previousFocus && typeof previousFocus.focus === 'function') previousFocus.focus();
+    }
+
+    // The dialog stays open on a rejected keyword. Closing it would throw away
+    // what the user typed to tell them it was wrong.
+    function confirm() {
+      var keyword = input.value.trim();
+      if (!keyword) { input.focus(); return; }
+      var scope = scopeSelect.value;
+      var filter;
+      try {
+        filter = buildKeywordFilter(keyword, scope);
+      } catch (err) {
+        showNotification(err.message, true);
+        input.focus();
+        return;
+      }
+      close();
+      onConfirm(keyword, scope, filter);
+    }
+  }
 
   function filterOnTitle(action, fluxes) {
     var articleTitle = articleTitleText(targetFlux);
     var feedId = targetFlux.dataset.feed;
+    if (!feedId) return;
 
-    var keyword = prompt(FILTER_PROMPTS[action], articleTitle);
-    if (keyword === null) return;
-    keyword = keyword.trim();
-    if (!keyword || !feedId) return;
+    openFilterDialog(action, articleTitle, function (keyword, scope, filter) {
+      addPermanentFilter(feedId, filter, action);
 
-    addPermanentFilter(feedId, buildTitleFilter(keyword), action);
-
-    // Apply it to what is already on screen. The server pass covers the rest of
-    // the feed but cannot touch this page's DOM. Scoped to the same feed as the
-    // saved rule — matching titles in other feeds are not what was asked for,
-    // and the rule will never act on them again.
-    var lower = keyword.toLowerCase();
-    var matched = 0;
-    fluxes.forEach(function (f) {
-      if (f.dataset.feed !== feedId) return;
-      if (articleTitleText(f).toLowerCase().indexOf(lower) !== -1) {
-        if (action === 'star') setStar(f, true);
-        else setRead(f, true);
-        matched++;
+      // Apply it to what is already on screen. The server pass covers the rest of
+      // the feed but cannot touch this page's DOM. Scoped to the same feed as the
+      // saved rule — matching articles in other feeds are not what was asked for,
+      // and the rule will never act on them again.
+      var lower = keyword.toLowerCase();
+      var matched = 0;
+      fluxes.forEach(function (f) {
+        if (f.dataset.feed !== feedId) return;
+        if (fluxMatches(f, lower, scope)) {
+          if (action === 'star') setStar(f, true);
+          else setRead(f, true);
+          matched++;
+        }
+      });
+      if (matched > 0) {
+        showNotification(matched + ' article' + (matched === 1 ? '' : 's') +
+          (action === 'star' ? ' starred' : ' marked read') + ' on page');
       }
     });
-    if (matched > 0) {
-      showNotification(matched + ' article' + (matched === 1 ? '' : 's') +
-        (action === 'star' ? ' starred' : ' marked read') + ' on page');
-    }
   }
 
   // ---------- Sidebar helpers ----------

--- a/xExtension-RightClickActions/static/style.css
+++ b/xExtension-RightClickActions/static/style.css
@@ -85,3 +85,104 @@
 .rca-actions { padding-left: 1.5em; }
 .rca-actions.rca-disabled { opacity: 0.4; }
 .rca-group-label { margin-top: 0.5em; margin-bottom: 0.2em; font-size: 0.85em; color: inherit; opacity: 0.6; font-weight: 600; }
+
+/* ── Filter dialog ── */
+
+/* Below the notification's 99999 so a rejected keyword's message is readable
+   over the dialog that is still holding what was typed. */
+.rca-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99998;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, .45);
+}
+
+.rca-dialog {
+  width: min(420px, calc(100vw - 32px));
+  padding: 18px;
+  border-radius: 8px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 13px;
+  background: #fff;
+  color: #222;
+  border: 1px solid #d0d0d0;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, .25);
+}
+
+.rca-dialog.frss-dark {
+  background: #2b2f36;
+  color: #e6e6e6;
+  border-color: #555;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, .6);
+}
+
+.rca-dialog-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.rca-dialog-input,
+.rca-dialog-select {
+  width: 100%;
+  padding: 7px 9px;
+  border-radius: 5px;
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 1px solid #c8c8c8;
+  box-sizing: border-box;
+}
+
+.rca-dialog.frss-dark .rca-dialog-input,
+.rca-dialog.frss-dark .rca-dialog-select {
+  border-color: #5a5a5a;
+  background: #21252b;
+}
+
+.rca-dialog-label {
+  display: block;
+  margin-top: 12px;
+  font-size: 12px;
+  opacity: .75;
+}
+
+.rca-dialog-label .rca-dialog-select {
+  margin-top: 4px;
+  opacity: 1;
+}
+
+.rca-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.rca-dialog-btn {
+  padding: 7px 14px;
+  border-radius: 5px;
+  font: inherit;
+  cursor: pointer;
+  color: inherit;
+  background: transparent;
+  border: 1px solid #c8c8c8;
+}
+
+.rca-dialog.frss-dark .rca-dialog-btn {
+  border-color: #5a5a5a;
+}
+
+.rca-dialog-btn-primary {
+  background: #1976d2;
+  border-color: #1976d2;
+  color: #fff;
+}
+
+.rca-dialog-btn:focus-visible {
+  outline: 2px solid #1976d2;
+  outline-offset: 1px;
+}


### PR DESCRIPTION
Companion to #30. Chris asked for the same choice in Right-Click Actions after seeing it in QuickFilter.

**Hide articles like this** and **Star articles like this** always wrote `intitle:"<keyword>"`. The prompt said as much — *"Hide articles with titles containing:"* — which was honest, but the title was the only thing the action could ever do, and the wording was covering for that.

## Change

The native `prompt()` cannot hold a second control, so it is a real dialog now: article title pre-filled and **selected** (the usual next move is cutting a headline down to one word), a **Match in** choice under it, Escape and Enter wired, focus returned where it came from, and the heading no longer naming the title.

| choice | saved as | reads |
|---|---|---|
| the title | `intitle:"…"` | the headline |
| the article body | `intext:"…"` | the stored content |
| the title or the body | `"…"` | either |

Same three operators as #30, verified in `Entry::matches()` at 1.28.1 and 1.29.1.

**No controller change.** `rcafilter` already takes a built filter string, normalises it through `FreshRSS_BooleanSearch`, and applies it retroactively via `markReadFeed()` / `listIdsWhere()` — all of which accept `intext:` and bare terms as-is. The retroactive sweep works for the new scopes without touching PHP.

**The on-page sweep follows the scope.** `app/views/helpers/index/article.phtml` renders `.text` unconditionally inside `.flux_content .content`, so the body of every entry in the stream is in the DOM and can be searched without opening anything. Worth knowing: it reads rendered text while core's `intext:` matches the stored **HTML**, so the server pass — authoritative, and already done by the time this runs — can match markup the page sweep cannot see.

## Deliberate refusal

A title-or-body keyword starting with `#` or `-`, or shaped `word:`, is refused with an explanation, and the dialog stays open holding what was typed rather than throwing it away to deliver the error. Same rule and same reason as #30: the bare term is the only form with no operator in front of it, so core stores `"#rust"` correctly and matches the right articles, but `Search::__toString()` drops the quotes it no longer needs and the rule reads back as a **tag**.

## One thing worth a second look

`handleAction()` runs *before* `hideMenu()`, and `hideMenu()` nulls `targetFlux`. With a blocking `prompt()` that never mattered. With an async dialog it does: the title and feed id are captured before the dialog opens, and nothing in the confirm callback reads `targetFlux`. Called out in a comment at the top of `openFilterDialog()` so the next change to it does not reintroduce the dependency.

## Verification

- `node --check` on `script.js`. No PHP changed.
- **Not run against a live FreshRSS.** The dialog, the scope operators, the body sweep and the refusal path are all unexercised against real data — Chris is testing this from `develop` along with #28 and #30.

Version 0.1.7 → 0.2.0.